### PR TITLE
Handle NaN values for rValue

### DIFF
--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.XML
             BHX.Material gbMaterial = new BHX.Material();
 
             double rValue = Math.Round(material.Thickness / material.MaterialProperties.Conductivity, 3);
-            if (double.IsInfinity(rValue)) rValue = -1; //Error
+            if (double.IsInfinity(rValue) || double.IsNaN(rValue)) rValue = -1; //Error
 
             gbMaterial.ID = "material-" + material.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
             gbMaterial.Name = material.Name;


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #174 

Handles NaN rValues to be `-1.0` instead, allowing it to be compliant with `v6.01` gbXML schema but highlighting an error in the rValue.


 ### Test files
N/A


 ### Changelog
### Fixed
 - `rValue` calculation - handling values which return a Not A Number `NaN` result
