### PR TITLE
Prevent duplicate names

### DIFF
--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -146,9 +146,9 @@ namespace BH.Adapter.XML
                 xmlSpace.ID = "Space-" + s.Number + "-" + s.Name;
                 xmlSpace.CADObjectID = BH.Engine.XML.Query.CadObjectId(space);
                 xmlSpace.ShellGeometry.ClosedShell.PolyLoop = BH.Engine.XML.Query.ClosedShellGeometry(space).ToArray();
-                xmlSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+                xmlSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
                 xmlSpace.SpaceBoundary = BH.Engine.XML.Query.SpaceBoundaries(space, uniqueBuildingElements);
-                xmlSpace.PlanarGeoemtry.ID = "SpacePlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+                xmlSpace.PlanarGeoemtry.ID = "SpacePlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
                 if (BH.Engine.Environment.Query.FloorGeometry(space) != null)
                 {
                     xmlSpace.PlanarGeoemtry.PolyLoop = BH.Engine.XML.Convert.ToGBXML(BH.Engine.Environment.Query.FloorGeometry(space));

--- a/XML_Adapter/Serialise/Level.cs
+++ b/XML_Adapter/Serialise/Level.cs
@@ -54,7 +54,7 @@ namespace BH.Adapter.XML
                 if (storeyGeometry == null)
                     continue;
                 storey.PlanarGeometry.PolyLoop = BH.Engine.XML.Convert.ToGBXML(storeyGeometry);
-                storey.PlanarGeometry.ID = "LevelPlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+                storey.PlanarGeometry.ID = "LevelPlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
                 storey.Name = level.Name;
                 storey.ID = "Level-" + level.Name.Replace(" ", "").ToLower();
                 storey.Level = (float)level.Elevation;

--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -47,13 +47,11 @@ namespace BH.Adapter.XML
         {
             List<BH.oM.XML.Opening> gbOpenings = new List<oM.XML.Opening>();
 
-            int openingCount = 0;
             foreach (BH.oM.Environment.Elements.Opening opening in openings)
             {
                 if (opening.OpeningCurve == null) continue;
 
                 BH.oM.XML.Opening gbOpening = BH.Engine.XML.Convert.ToGBXML(opening);
-                gbOpening.PlanarGeometry.ID = "openingPGeom" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
 
                 //Normals away from space
                 if (!BH.Engine.Environment.Query.NormalAwayFromSpace(opening.OpeningCurve.ICollapseToPolyline(BH.oM.Geometry.Tolerance.Angle), space))
@@ -89,9 +87,6 @@ namespace BH.Adapter.XML
                     }
                 }
 
-                gbOpening.ID = "opening-" + openingCount.ToString() + "-" + opening.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
-                gbOpening.Name = "opening-" + openingCount.ToString();
-                openingCount++;
                 if (exportType == ExportType.gbXMLIES)
                     gbOpening.ConstructionIDRef = BH.Engine.XML.Query.ConstructionID(buildingElement); //Only for IES!
                 else

--- a/XML_Engine/Convert/Architecture_oM/Level.cs
+++ b/XML_Engine/Convert/Architecture_oM/Level.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.XML
                     storey.PlanarGeometry.PolyLoop = storeyGeometry.ToGBXML();
             }
 
-            storey.PlanarGeometry.ID = "level-planar-geometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            storey.PlanarGeometry.ID = "level-planar-geometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
             storey.Name = level.Name;
             storey.ID = "Level-" + level.Name.Replace(" ", "").ToLower();
             storey.Level = (float)level.Elevation;

--- a/XML_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/XML_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.XML
 
             BHX.RectangularGeometry geom = element.ToGBXMLGeometry();
             BHX.PlanarGeometry planarGeom = new BHX.PlanarGeometry();
-            planarGeom.ID = "PlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            planarGeom.ID = "PlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
             BHG.Polyline pLine = new BHG.Polyline() { ControlPoints = element.PanelCurve.IControlPoints() };
             planarGeom.PolyLoop = pLine.ToGBXML();
@@ -95,7 +95,7 @@ namespace BH.Engine.XML
             geom.Height = Math.Round(element.Height(), 3);
             geom.Width = Math.Round(element.Width(), 3);
             geom.CartesianPoint = pLine.ControlPoints.First().ToGBXML();
-            geom.ID = "geom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            geom.ID = "geom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
             return geom;
         }

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -61,7 +61,7 @@ namespace BH.Engine.XML
         {
             BHX.Layer l = new BHX.Layer();
 
-            l.ID = "layer-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            l.ID = "layer-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
             List<BHX.MaterialId> materialIDs = new List<BHX.MaterialId>();
             foreach (BHX.Material m in materials)

--- a/XML_Engine/Convert/Environment_oM/Opening.cs
+++ b/XML_Engine/Convert/Environment_oM/Opening.cs
@@ -43,13 +43,14 @@ namespace BH.Engine.XML
 
             BHG.Polyline pLine = new oM.Geometry.Polyline() { ControlPoints = opening.OpeningCurve.IControlPoints() };
 
+            jsonOpening.Name = "opening-" + opening.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
             jsonOpening.ID = "opening-" + opening.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
             jsonOpening.PlanarGeometry.PolyLoop = pLine.ToGBXML();
-            jsonOpening.PlanarGeometry.ID = "openingPGeom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            jsonOpening.PlanarGeometry.ID = "openingPGeom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
             jsonOpening.RectangularGeometry.CartesianPoint = Geometry.Query.Centre(pLine).ToGBXML();
             jsonOpening.RectangularGeometry.Height = Math.Round(opening.Height(), 3);
             jsonOpening.RectangularGeometry.Width = Math.Round(opening.Width(), 3);
-            jsonOpening.RectangularGeometry.ID = "rGeomOpening-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            jsonOpening.RectangularGeometry.ID = "rGeomOpening-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
             return jsonOpening;
         }

--- a/XML_Engine/Convert/Environment_oM/Space.cs
+++ b/XML_Engine/Convert/Environment_oM/Space.cs
@@ -51,9 +51,9 @@ namespace BH.Engine.XML
             gbSpace.ID = "Space-" + space.Number + "-" + space.Name;
             gbSpace.CADObjectID = elementsAsSpace.CADObjectID();
             gbSpace.ShellGeometry.ClosedShell.PolyLoop = elementsAsSpace.ClosedShellGeometry().ToArray();
-            gbSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            gbSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
             gbSpace.SpaceBoundary = elementsAsSpace.SpaceBoundaries(uniqueBuildingElements);
-            gbSpace.PlanarGeoemtry.ID = "SpacePlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+            gbSpace.PlanarGeoemtry.ID = "SpacePlanarGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
             if (elementsAsSpace.FloorGeometry() != null)
             {
                 gbSpace.PlanarGeoemtry.PolyLoop = elementsAsSpace.FloorGeometry().ToGBXML();

--- a/XML_Engine/Query/SpaceBoundaries.cs
+++ b/XML_Engine/Query/SpaceBoundaries.cs
@@ -95,7 +95,7 @@ namespace BH.Engine.XML
             {
                 PlanarGeometry planarGeom = new PlanarGeometry();
                 planarGeom.PolyLoop = pLoops[x];
-                planarGeom.ID = "pGeom" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
+                planarGeom.ID = "pGeom" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
                 boundaries[x] = new SpaceBoundary { PlanarGeometry = planarGeom };
 
                 //Get the ID from the referenced element


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #170 

Increases the `substring` length of the `GUID` from `5` to `10` to decrease the likelihood of duplicated names in `PlanarGeometry`. 
Also changes `opening` name to rely on `GUID` as well to be more unique than `opening-x`


 ### Test files
N/A


 ### Changelog
### Fixed
 - Decreased likelihood of duplicated IDs in gbXML objects