### PR TITLE
Update ElementID usage across XML Toolkit

### DIFF
--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -64,7 +64,7 @@ namespace BH.Adapter.XML
                 if (opening.CustomData.ContainsKey("Revit_elementId"))
                 {
                     string elementID = (opening.CustomData["Revit_elementId"]).ToString();
-                    buildingElement = allElements.Find(x => x != null && x.CustomData.ContainsKey("Revit_elementId") && x.CustomData["Revit_elementId"].ToString() == elementID);
+                    buildingElement = allElements.Find(x => x != null && x.ElementID == elementID);
                     //buildingElement = allElements.Find(x => x != null && x.Openings.Find(y => y.BHoM_Guid == opening.BHoM_Guid) != null);
 
                     if (buildingElement != null)

--- a/XML_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/XML_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -110,8 +110,13 @@ namespace BH.Engine.XML
             foreach (BHX.Opening opening in surface.Opening)
                 buildingElement.Openings.Add(opening.ToBHoM());
 
-            buildingElement.Name = surface.CADObjectID.Split('[')[0].Trim();
-            buildingElement.BuildingElementProperties.Name = surface.CADObjectID.Split('[')[0].Trim();
+            string[] cadSplit = surface.CADObjectID.Split('[');
+            if(cadSplit.Length > 0)
+                buildingElement.Name = cadSplit[0].Trim();
+            if (cadSplit.Length > 1)
+                buildingElement.ElementID = cadSplit[1].Split(']')[0].Trim();
+
+            buildingElement.BuildingElementProperties.Name = buildingElement.Name;
 
             return buildingElement;
         }

--- a/XML_Engine/Convert/Environment_oM/Opening.cs
+++ b/XML_Engine/Convert/Environment_oM/Opening.cs
@@ -75,7 +75,7 @@ namespace BH.Engine.XML
             if (opening.CustomData.ContainsKey("Revit_elementId"))
             {
                 string elementID = (opening.CustomData["Revit_elementId"]).ToString();
-                buildingElement = allElements.Find(x => x != null && x.CustomData.ContainsKey("Revit_elementId") && x.CustomData["Revit_elementId"].ToString() == elementID);
+                buildingElement = allElements.Find(x => x != null && x.ElementID == elementID);
 
                 if (buildingElement != null)
                 {

--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -44,9 +44,7 @@ namespace BH.Engine.XML
 
             if (element.BuildingElementProperties != null)
             {
-                //TODO: Make this non-dependent on Revit somehow so we can do the same thing but from another adapter, e.g. info pulled from TAS or from another gbXML
-                if (element.CustomData.ContainsKey("Revit_elementId"))
-                    revitElementID = element.CustomData["Revit_elementId"].ToString();
+                revitElementID = element.ElementID;
 
                 // change only Basic Wall and keep Curtain as it is
                 if (exportType == ExportType.gbXMLIES && element.Name.Contains("GLZ") && (element.Name.Contains("Basic Wall") || element.Name.Contains("Floor") || element.Name.Contains("Roof")))
@@ -105,7 +103,7 @@ namespace BH.Engine.XML
             if (bHoMOpening.CustomData.ContainsKey("Revit_elementId"))
             {
                 string elementID = (bHoMOpening.CustomData["Revit_elementId"]).ToString();
-                BHE.BuildingElement buildingElement = buildingElementsList.Find(x => x != null && x.CustomData.ContainsKey("Revit_elementId") && x.CustomData["Revit_elementId"].ToString() == elementID);
+                BHE.BuildingElement buildingElement = buildingElementsList.Find(x => x != null && x.ElementID == elementID);
                 if (buildingElement != null && buildingElement.BuildingElementProperties.CustomData.ContainsKey("Family Name"))
                 {
                     familyName = buildingElement.BuildingElementProperties.CustomData["Family Name"].ToString();


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #179 

Converts usage of `Revit_elementId` in `BuildingElement` to `ElementID` - but we still need a few more additional places where this is captured... Issues raised on BHoM for later taking up.


 ### Test files
N/A

 ### Changelog
#### Changed
 - References to `Revit_elementId` on `BuildingElement` custom data to `ElementID` property