### PR TITLE
Protecting against users including a .xml file extension

### DIFF
--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -45,6 +45,12 @@ namespace BH.Adapter.XML
             ExportType = exportType;
             ExportDetail = exportDetail;
 
+            if(System.IO.Path.HasExtension(ProjectName) && System.IO.Path.GetExtension(ProjectName) == ".xml")
+            {
+                BH.Engine.Reflection.Compute.RecordError("Project Name cannot contain a file extension");
+                return;
+            }
+
             AdapterId = "XML_Adapter";
             Config.MergeWithComparer = false;   //Set to true after comparers have been implemented
             Config.ProcessInMemory = false;

--- a/XML_Adapter/XML_Adapter.csproj
+++ b/XML_Adapter/XML_Adapter.csproj
@@ -62,6 +62,10 @@
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_Engine, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #154 

Gives the user an error message if they include a `.xml` file extension in the `ProjectName` input.


 ### Test files
N/A


 ### Changelog
#### Added
 - Protection to pulling XML files by ensuring users do not include `.xml` in their `ProjectName` inputs.