### PR TITLE
Xml tooolkit issue195 remove construction from shade

### DIFF
--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -182,7 +182,7 @@ namespace BH.Adapter.XML
 
             if (exportType == ExportType.gbXMLIES)
                 gbx.WindowType = usedWindows.ToArray();
-            else if (exportType == ExportType.gbXMLTAS)//We have to force nill otherwise WindowType will be created
+            else if (exportType == ExportType.gbXMLTAS)//We have to force null otherwise WindowType will be created
                 gbx.WindowType = null;
         }
 
@@ -204,7 +204,7 @@ namespace BH.Adapter.XML
 
                 if (exportType == ExportType.gbXMLIES)
                     gbSrf.ConstructionIDRef = be.ConstructionID();
-                else if (exportType == ExportType.gbXMLTAS) //We have to force nill otherwise Construction will be created
+                else if (exportType == ExportType.gbXMLTAS) //We have to force null otherwise Construction will be created
                     gbSrf.ConstructionIDRef = null;
 
                 gbx.Campus.Surface.Add(gbSrf);

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -179,7 +179,11 @@ namespace BH.Adapter.XML
             gbx.Construction = usedConstructions.ToArray();
             gbx.Layer = usedLayers.ToArray();
             gbx.Material = usedMaterials.ToArray();
-            gbx.WindowType = usedWindows.ToArray();
+
+            if (exportType == ExportType.gbXMLIES)
+                gbx.WindowType = usedWindows.ToArray();
+            else if (exportType == ExportType.gbXMLTAS)
+                gbx.WindowType = null;
         }
 
         public static void SerializeCollection(IEnumerable<BuildingElement> inputElements, BH.oM.XML.GBXML gbx, ExportType exportType)
@@ -198,7 +202,10 @@ namespace BH.Adapter.XML
                 if (be.BuildingElementProperties != null)
                     gbSrf.CADObjectID = be.CADObjectID();
 
-                gbSrf.ConstructionIDRef = be.ConstructionID();
+                if (exportType == ExportType.gbXMLIES)
+                    gbSrf.ConstructionIDRef = be.ConstructionID();
+                else if (exportType == ExportType.gbXMLTAS)
+                    gbSrf.ConstructionIDRef = null;
 
                 gbx.Campus.Surface.Add(gbSrf);
             }

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -182,7 +182,7 @@ namespace BH.Adapter.XML
 
             if (exportType == ExportType.gbXMLIES)
                 gbx.WindowType = usedWindows.ToArray();
-            else if (exportType == ExportType.gbXMLTAS)
+            else if (exportType == ExportType.gbXMLTAS)//We have to force nill otherwise WindowType will be created
                 gbx.WindowType = null;
         }
 
@@ -204,7 +204,7 @@ namespace BH.Adapter.XML
 
                 if (exportType == ExportType.gbXMLIES)
                     gbSrf.ConstructionIDRef = be.ConstructionID();
-                else if (exportType == ExportType.gbXMLTAS)
+                else if (exportType == ExportType.gbXMLTAS) //We have to force nill otherwise Construction will be created
                     gbSrf.ConstructionIDRef = null;
 
                 gbx.Campus.Surface.Add(gbSrf);


### PR DESCRIPTION


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Fixes #194
Fixes #195 
Fixes #196 

 <!-- Add short description of what has been fixed -->
Fixes Tas version of BHoM gbXML export

 ### Test files
<!-- Link to test files to validate the proposed changes -->
It is working on [sample file ](https://github.com/BHoM/samples/tree/master/gbXML_Toolkit)

 ### Changelog
#### Fixed 
 - Fixed Construction for Shades, Windows and transformation of GLZ object in TAS version of export
