### PR TITLE
XML_Toolkit - several minor compliance fixes

### DIFF
--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -186,7 +186,9 @@ namespace BH.Adapter.XML
                                 conc.LayerID.LayerIDRef = layer.ID;
 
                                 usedConstructions.Add(conc);
-                                usedLayers.Add(layer);
+                                
+                                if(usedLayers.Where(y => y.ID == layer.ID).FirstOrDefault() == null)
+                                    usedLayers.Add(layer);
 
                                 foreach(BH.oM.XML.Material mat in materials)
                                 {

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -123,10 +123,10 @@ namespace BH.Adapter.XML
                             {
                                 curtainElementProperties.BuildingElementType = BuildingElementType.CurtainWall;
                                 curtainElementProperties.Construction = elementProperties.Construction;
-
-                                //Update the host elements element type
-                                srf.SurfaceType = (adjacentSpaces.Count == 1 ? BuildingElementType.WallExternal : BuildingElementType.WallInternal).ToGBXML();
                             }
+
+                            //Update the host elements element type
+                            srf.SurfaceType = (adjacentSpaces.Count == 1 ? BuildingElementType.WallExternal : BuildingElementType.WallInternal).ToGBXML();
 
                             curtainWallOpening.ExtendedProperties.Add(curtainWallProperties);
                             curtainWallOpening.ExtendedProperties.Add(curtainElementProperties);
@@ -148,13 +148,19 @@ namespace BH.Adapter.XML
                         srf.Opening = Serialize(space[x].Openings, space, allElements, elementsAsSpaces, spaces, gbx, exportType).ToArray();
                         foreach(BH.oM.Environment.Elements.Opening o in space[x].Openings)
                         {
+                            string nameCheck = "";
+
+                            BHP.EnvironmentContextProperties openingEnvContextProperties = o.EnvironmentContextProperties() as BHP.EnvironmentContextProperties;
                             BHP.ElementProperties openingElementProperties = o.ElementProperties() as BHP.ElementProperties;
-                            if(openingElementProperties != null)
-                            {
-                                var t = usedWindows.Where(a => a.Name == BH.Engine.XML.Query.GetCleanName(openingElementProperties.Construction.Name)).FirstOrDefault();
-                                if (t == null)
-                                    usedWindows.Add(openingElementProperties.Construction.ToGBXMLWindow(o));
-                            }
+
+                            if (openingEnvContextProperties != null)
+                                nameCheck = openingEnvContextProperties.TypeName;
+                            else if (openingElementProperties != null && openingElementProperties.Construction != null)
+                                nameCheck = openingElementProperties.Construction.Name;
+                            
+                            var t = usedWindows.Where(a => a.Name == nameCheck).FirstOrDefault();
+                            if (t == null)
+                                usedWindows.Add(openingElementProperties.Construction.ToGBXMLWindow(o));
                         }
                     }
 

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -94,7 +94,7 @@ namespace BH.Adapter.XML
 
                     if (exportType == ExportType.gbXMLIES)
                     {
-                        srf.ConstructionIDRef = (envContextProperties != null ? envContextProperties.TypeName.GetCleanName().Replace(" ", "-") : space[x].ConstructionID());
+                        srf.ConstructionIDRef = (envContextProperties != null ? envContextProperties.TypeName.CleanName() : space[x].ConstructionID());
 
                         //If the surface is a basic Wall: SIM_EXT_GLZ so Curtain Wall after CADObjectID translation add the wall as an opening
                         if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ"))
@@ -187,7 +187,12 @@ namespace BH.Adapter.XML
 
                                 usedConstructions.Add(conc);
                                 usedLayers.Add(layer);
-                                usedMaterials.AddRange(materials);
+
+                                foreach(BH.oM.XML.Material mat in materials)
+                                {
+                                    if (usedMaterials.Where(y => y.ID == mat.ID).FirstOrDefault() == null)
+                                        usedMaterials.Add(mat);
+                                }
                             }
                         }
                     }

--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -89,7 +89,7 @@ namespace BH.Adapter.XML
                         gbOpening.OpeningType = "NonSlidingDoor";
 
                     if (exportType == ExportType.gbXMLIES)
-                        gbOpening.WindowTypeIDRef = (contextProperties == null? elementProperties.Construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+                        gbOpening.WindowTypeIDRef = "window-" + (contextProperties == null? elementProperties.Construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
                     else
                         gbOpening.WindowTypeIDRef = null;
                 }

--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -79,6 +79,9 @@ namespace BH.Adapter.XML
                     gbOpening.CADObjectID = opening.CADObjectID(exportType);
                     gbOpening.OpeningType = elementProperties.ToGBXMLType();
 
+                    if (gbOpening.OpeningType.ToLower() == "fixedwindow" && contextProperties != null && contextProperties.TypeName.ToLower().Contains("skylight"))
+                        gbOpening.OpeningType = "FixedSkylight";
+
                     if (familyName == "System Panel") //No SAM_BuildingElementType for this one atm
                         gbOpening.OpeningType = "FixedWindow";
 

--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -89,7 +89,7 @@ namespace BH.Adapter.XML
                         gbOpening.OpeningType = "NonSlidingDoor";
 
                     if (exportType == ExportType.gbXMLIES)
-                        gbOpening.WindowTypeIDRef = "window-" + (contextProperties == null? elementProperties.Construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+                        gbOpening.WindowTypeIDRef = "window-" + (contextProperties == null? elementProperties.Construction.Name.CleanName() : contextProperties.TypeName.CleanName());
                     else
                         gbOpening.WindowTypeIDRef = null;
                 }

--- a/XML_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/XML_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.XML
 
             BHX.Surface surface = new BHX.Surface();
             surface.CADObjectID = element.CADObjectID();
-            surface.ConstructionIDRef = (contextProperties == null ? element.ConstructionID() : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+            surface.ConstructionIDRef = (contextProperties == null ? element.ConstructionID() : contextProperties.TypeName.CleanName());
 
             BHX.RectangularGeometry geom = element.ToGBXMLGeometry();
             BHX.PlanarGeometry planarGeom = new BHX.PlanarGeometry();

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -96,7 +96,7 @@ namespace BH.Engine.XML
             BHP.BuildingElementAnalyticalProperties extraProperties = opening.PropertiesByType(typeof(BHP.BuildingElementAnalyticalProperties)) as BHP.BuildingElementAnalyticalProperties;
             BHP.EnvironmentContextProperties contextProperties = opening.EnvironmentContextProperties() as BHP.EnvironmentContextProperties;
 
-            window.ID = (contextProperties == null ? "window-" + construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+            window.ID = "window-" + (contextProperties == null ? construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
             window.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
             window.UValue.Value = (extraProperties == null ? "0" : extraProperties.UValue.ToString());
             window.Transmittance.Value = (extraProperties == null ? "0" : extraProperties.LTValue.ToString());

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -80,7 +80,7 @@ namespace BH.Engine.XML
                 analysisProperties = element.AnalyticalProperties() as BHP.BuildingElementAnalyticalProperties;
             }
 
-            gbConstruction.ID = (contextProperties == null ? construction.ConstructionID() : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+            gbConstruction.ID = (contextProperties == null ? construction.ConstructionID() : contextProperties.TypeName.CleanName().Replace(" ", "-"));
             gbConstruction.Absorptance = construction.ToGBXMLAbsorptance();
             gbConstruction.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
             gbConstruction.Roughness = construction.Roughness.ToGBXML();
@@ -96,7 +96,7 @@ namespace BH.Engine.XML
             BHP.BuildingElementAnalyticalProperties extraProperties = opening.PropertiesByType(typeof(BHP.BuildingElementAnalyticalProperties)) as BHP.BuildingElementAnalyticalProperties;
             BHP.EnvironmentContextProperties contextProperties = opening.EnvironmentContextProperties() as BHP.EnvironmentContextProperties;
 
-            window.ID = "window-" + (contextProperties == null ? construction.Name.GetCleanName().Replace(" ", "-") : contextProperties.TypeName.GetCleanName().Replace(" ", "-"));
+            window.ID = "window-" + (contextProperties == null ? construction.Name.CleanName() : contextProperties.TypeName.CleanName());
             window.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
             window.UValue.Value = (extraProperties == null ? "0" : extraProperties.UValue.ToString());
             window.Transmittance.Value = (extraProperties == null ? "0" : extraProperties.LTValue.ToString());

--- a/XML_Engine/Convert/Environment_oM/ElementType.cs
+++ b/XML_Engine/Convert/Environment_oM/ElementType.cs
@@ -78,23 +78,22 @@ namespace BH.Engine.XML
             {
                 case BHE.BuildingElementType.Ceiling:
                     return "Ceiling";
-                case oM.Environment.Elements.BuildingElementType.CurtainWall:
-                    return "ExteriorWall";
-                case oM.Environment.Elements.BuildingElementType.Door:
+                case BHE.BuildingElementType.Door:
                     return "NonSlidingDoor";
-                case oM.Environment.Elements.BuildingElementType.Floor:
+                case BHE.BuildingElementType.Floor:
                     return "Floor";
-                case oM.Environment.Elements.BuildingElementType.FloorExposed:
+                case BHE.BuildingElementType.FloorExposed:
                     return "ExposedFloor";
-                case oM.Environment.Elements.BuildingElementType.FloorInternal:
+                case BHE.BuildingElementType.FloorInternal:
                     return "InternalFloor";
-                case oM.Environment.Elements.BuildingElementType.FloorRaised:
+                case BHE.BuildingElementType.FloorRaised:
                     return "RaisedFloor";
                 case BHE.BuildingElementType.Frame:
                     return "Frame";
                 case BHE.BuildingElementType.Glazing:
                 case BHE.BuildingElementType.Window:
                 case BHE.BuildingElementType.WindowWithFrame:
+                case BHE.BuildingElementType.CurtainWall:
                     return "FixedWindow";
                 case BHE.BuildingElementType.Roof:
                     return "Roof";

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -46,7 +46,8 @@ namespace BH.Engine.XML
             double rValue = Math.Round(material.Thickness / material.MaterialProperties.Conductivity, 3);
             if (double.IsInfinity(rValue) || double.IsNaN(rValue)) rValue = -1; //Error
 
-            gbMaterial.ID = "material-" + material.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
+            //gbMaterial.ID = "material-" + material.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
+            gbMaterial.ID = "material-" + material.Name.CleanName();
             gbMaterial.Name = material.Name;
             gbMaterial.RValue.Value = rValue.ToString();
             gbMaterial.Thickness = Math.Round(material.Thickness, 3);

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -98,7 +98,7 @@ namespace BH.Engine.XML
 
             BHX.Glaze glaze = new BHX.Glaze();
 
-            glaze.ID = "glaze-" + material.Name.Replace(" ", "-");
+            glaze.ID = "glaze-" + material.Name.Replace(" ", "-").Replace(",", "") + material.BHoM_Guid.ToString().Substring(0, 5);
             glaze.Name = material.Name;
             glaze.Thickness.Value = Math.Round(material.Thickness, 4).ToString();
             glaze.Conductivity.Value = props.Conductivity.ToString();
@@ -133,7 +133,7 @@ namespace BH.Engine.XML
 
             BHX.Gap gap = new BHX.Gap();
 
-            gap.ID = "gap-" + material.Name.Replace(" ", "-");
+            gap.ID = "gap-" + material.Name.Replace(" ", "-").Replace(",", "") + material.BHoM_Guid.ToString().Substring(0, 5);
             gap.Name = material.Name;
             gap.Thickness.Value = Math.Round(material.Thickness, 4).ToString();
             gap.Conductivity.Value = Math.Round(props.Conductivity, 3).ToString();

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -62,11 +62,12 @@ namespace BH.Engine.XML
         {
             BHX.Layer l = new BHX.Layer();
 
-            l.ID = "layer-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
+            l.ID = "layer";// + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
             List<BHX.MaterialId> materialIDs = new List<BHX.MaterialId>();
             foreach (BHX.Material m in materials)
             {
+                l.ID += "-" + m.Name.CleanName();
                 BHX.MaterialId id = new BHX.MaterialId();
                 id.MaterialIDRef = m.ID;
                 materialIDs.Add(id);

--- a/XML_Engine/Query/CleanName.cs
+++ b/XML_Engine/Query/CleanName.cs
@@ -37,18 +37,20 @@ namespace BH.Engine.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        static public string GetCleanName(this string Name)
+        static public string CleanName(this string name)
         {
-            if (Name == null)
+            if (name == null)
                 return null;
 
-            if (Name == string.Empty)
+            if (name == string.Empty)
                 return string.Empty;
 
-            string aName = Name.Replace(":", "_");
-            aName = aName.Replace(" ", string.Empty);
+            name = name.Replace(":", "_");
+            name = name.Replace(" ", "");
+            name = name.Replace(",", "");
+            name = name.Replace("/", "");
 
-            return aName;
+            return name;
         }
     }
 }

--- a/XML_Engine/XML_Engine.csproj
+++ b/XML_Engine/XML_Engine.csproj
@@ -89,7 +89,7 @@
     <Compile Include="Create\DocumentBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\AdjacentSpace.cs" />
-    <Compile Include="Query\GetCleanName.cs" />
+    <Compile Include="Query\CleanName.cs" />
     <Compile Include="Query\ExternalElements.cs" />
     <Compile Include="Query\PolygonCentre.cs" />
     <Compile Include="Query\CADObjectError.cs" />


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #209 
Fixes #210 
Fixes #211 
Fixes #213 
Fixes #214 
Fixes #215 
Fixes #216 
Fixes #217 
Fixes #219 

 ### Test files
[Test files here, includes a TAS TBD file to pull from and GH/Dynamo scripts to produce the gbXML files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?e=5%3A13100847e96e4d5c8e31d025db2ba0e0&at=9&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FXML_Toolkit%2FXML_Toolkit-Issue209)

A lot of these issues are schema issues however, and testing of them should be done on this [website](http://gbxml.org/validator/Pages/TestPage.aspxl) using Schema `6.01` and test case `Whole Building Test 1`


 ### Changelog
#### Fixed
 - Fixed a number of small schema issues
 - Fixed duplicate materials,constructions and layers appearing within the XML export