### PR TITLE
Fix floor convert and document builder protection

### DIFF
--- a/XML_Engine/Convert/Environment_oM/ElementType.cs
+++ b/XML_Engine/Convert/Environment_oM/ElementType.cs
@@ -81,11 +81,10 @@ namespace BH.Engine.XML
                 case BHE.BuildingElementType.Door:
                     return "NonSlidingDoor";
                 case BHE.BuildingElementType.Floor:
-                    return "Floor";
                 case BHE.BuildingElementType.FloorExposed:
                     return "ExposedFloor";
                 case BHE.BuildingElementType.FloorInternal:
-                    return "InternalFloor";
+                    return "InteriorFloor";
                 case BHE.BuildingElementType.FloorRaised:
                     return "RaisedFloor";
                 case BHE.BuildingElementType.Frame:

--- a/XML_Engine/Create/DocumentBuilder.cs
+++ b/XML_Engine/Create/DocumentBuilder.cs
@@ -66,6 +66,7 @@ namespace BH.Engine.XML
             openings.AddRange(buildingElements.ElementsByType(BuildingElementType.WindowWithFrame));
 
             List<BuildingElement> shadingElements = buildingElements.ShadingElements();
+            buildingElements = buildingElements.ElementsWithoutType(BuildingElementType.Shade); //Remove shading if it exists
 
             List<string> uniqueSpaceNames = buildingElements.UniqueSpaceNames();
 

--- a/XML_Engine/Query/CleanName.cs
+++ b/XML_Engine/Query/CleanName.cs
@@ -49,6 +49,8 @@ namespace BH.Engine.XML
             name = name.Replace(" ", "");
             name = name.Replace(",", "");
             name = name.Replace("/", "");
+            name = name.Replace("(", "");
+            name = name.Replace(")", "");
 
             return name;
         }

--- a/XML_oM/GBXML/Window/Gap.cs
+++ b/XML_oM/GBXML/Window/Gap.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML
     public class Gap : GBXMLObject
     {
         [XmlAttribute("id")]
-        public string ID { get; set; } = "GapIdentification";
+        public string ID { get; set; } = "GapIdentification" + Guid.NewGuid().ToString().Substring(0, 5);
 
         [XmlAttribute("gas")]
         public string Gas { get; set; } = "Argon";

--- a/XML_oM/GBXML/Window/Glaze.cs
+++ b/XML_oM/GBXML/Window/Glaze.cs
@@ -34,7 +34,7 @@ namespace BH.oM.XML
     public class Glaze : GBXMLObject
     {
         [XmlAttribute("id")]
-        public string ID { get; set; } = "GlazingIdentification";
+        public string ID { get; set; } = "GlazingIdentification" + Guid.NewGuid().ToString().Substring(0, 5);
 
         [XmlElement("Name", Order = 1)]
         public string Name { get; set; } = "Glazing";


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #225 
Fixes #226 


 ### Test files
[Test files here, includes a TAS TBD file to pull from and GH/Dynamo scripts to produce the gbXML files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?e=5%3A13100847e96e4d5c8e31d025db2ba0e0&at=9&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FXML_Toolkit%2FXML_Toolkit-Issue209)


 ### Changelog
#### Fixed
 - Fixed `InteriorFloor` export type
 - Fixed `DocumentBuilder` protection against `Shade` elements


 ### Additional comments
<!-- As required -->