### PR TITLE
XML_Toolkit: Minor issues fixed

### DIFF
--- a/XML_Adapter/Serialise/Building.cs
+++ b/XML_Adapter/Serialise/Building.cs
@@ -28,6 +28,7 @@ using System.Linq;
 
 using BH.Engine.Environment;
 using BHP = BH.oM.Environment.Properties;
+using BH.Engine.XML;
 
 namespace BH.Adapter.XML
 {
@@ -40,9 +41,11 @@ namespace BH.Adapter.XML
         public static void SerializeCollection(IEnumerable<Building> inputBuildings, BH.oM.XML.GBXML gbx, bool isIES)
         {
             List<Building> buildings = inputBuildings.ToList();
+            gbx.Campus.Building = new oM.XML.Building[buildings.Count];
             for(int x = 0; x < buildings.Count; x++)
             {
-                gbx.Campus.Location = BH.Engine.XML.Convert.ToGBXMLLocation(buildings[x]);
+                gbx.Campus.Building[x] = buildings[x].ToGBXML();
+                gbx.Campus.Location = buildings[x].ToGBXMLLocation();
 
                 if (buildings[x].ContextProperties() != null)
                 {

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -244,6 +244,15 @@ namespace BH.Adapter.XML
                 gbx.WindowType = usedWindows.ToArray();
             else if (exportType == ExportType.gbXMLTAS)//We have to force null otherwise WindowType will be created
                 gbx.WindowType = null;
+
+            //Set the building area
+            List<BuildingElement> floorElements = allElements.Where(x => (x.ElementProperties() as BHP.ElementProperties) != null && ((x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.Floor || (x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.FloorExposed || (x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.FloorInternal || (x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.FloorRaised || (x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.SlabOnGrade || (x.ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.UndergroundSlab)).ToList();
+
+            double buildingFloorArea = 0;
+            foreach (BuildingElement be in floorElements)
+                buildingFloorArea += be.Area();
+
+            gbx.Campus.Building[0].Area = buildingFloorArea;
         }
 
         public static void SerializeCollection(IEnumerable<BuildingElement> inputElements, BH.oM.XML.GBXML gbx, ExportType exportType)

--- a/XML_Adapter/Serialise/BuildingElement.cs
+++ b/XML_Adapter/Serialise/BuildingElement.cs
@@ -97,7 +97,7 @@ namespace BH.Adapter.XML
                         srf.ConstructionIDRef = (envContextProperties != null ? envContextProperties.TypeName.CleanName() : space[x].ConstructionID());
 
                         //If the surface is a basic Wall: SIM_EXT_GLZ so Curtain Wall after CADObjectID translation add the wall as an opening
-                        if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ"))
+                        if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ") && (space[x].ElementProperties() as BHP.ElementProperties).BuildingElementType != BuildingElementType.CurtainWall)
                         {
                             List<BHG.Polyline> newOpeningBounds = new List<oM.Geometry.Polyline>();
                             if (space[x].Openings.Count > 0)
@@ -125,14 +125,16 @@ namespace BH.Adapter.XML
                                 curtainElementProperties.Construction = elementProperties.Construction;
                             }
 
-                            //Update the host elements element type
-                            srf.SurfaceType = (adjacentSpaces.Count == 1 ? BuildingElementType.WallExternal : BuildingElementType.WallInternal).ToGBXML();
-                            srf.ExposedToSun = BH.Engine.Environment.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
-
                             curtainWallOpening.ExtendedProperties.Add(curtainWallProperties);
                             curtainWallOpening.ExtendedProperties.Add(curtainElementProperties);
 
                             space[x].Openings.Add(curtainWallOpening);
+                        }
+                        else if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ") && (space[x].ElementProperties() as BHP.ElementProperties).BuildingElementType == BuildingElementType.CurtainWall)
+                        {
+                            //Update the host elements element type
+                            srf.SurfaceType = (adjacentSpaces.Count == 1 ? BuildingElementType.WallExternal : BuildingElementType.WallInternal).ToGBXML();
+                            srf.ExposedToSun = BH.Engine.Environment.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
                         }
                     }
                     else if (exportType == ExportType.gbXMLTAS)

--- a/XML_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/XML_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -103,6 +103,11 @@ namespace BH.Engine.XML
             geom.CartesianPoint = pLine.ControlPoints.First().ToGBXML();
             geom.ID = "geom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);
 
+            if(geom.Height == 0)
+                geom.Height = Math.Round(element.Area() / geom.Width, 3);
+            if (geom.Width == 0)
+                geom.Width = Math.Round(element.Area() / geom.Height, 3);
+
             return geom;
         }
 

--- a/XML_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/XML_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -61,7 +61,10 @@ namespace BH.Engine.XML
 
             surface.Opening = new BHX.Opening[element.Openings.Count];
             for (int x = 0; x < element.Openings.Count; x++)
-                surface.Opening[x] = element.Openings[x].ToGBXML();
+            {
+                if(element.Openings[x].OpeningCurve.IControlPoints().Count != 0)
+                    surface.Opening[x] = element.Openings[x].ToGBXML();
+            }
 
             return surface;
         }

--- a/XML_Engine/Convert/Geometry_oM/Polyline.cs
+++ b/XML_Engine/Convert/Geometry_oM/Polyline.cs
@@ -41,6 +41,7 @@ namespace BH.Engine.XML
             BHX.Polyloop polyloop = new BHX.Polyloop();
 
             List<BHG.Point> pts = pLine.DiscontinuityPoints();
+            if (pts.Count == 0) return polyloop;
 
             int count = ((pts.First().SquareDistance(pts.Last()) < (tolerance * tolerance)) ? pts.Count - 1 : pts.Count);
             List<BHX.CartesianPoint> cartpoint = new List<BHX.CartesianPoint>();

--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -77,7 +77,7 @@ namespace BH.Engine.XML
 
             return CADObjectID;*/
 
-            return "FIX CAD OBJECT ID FOR SPACE";
+            return "[" + space.CommonSpaceName() + "]"; //ToDo: Fix this properly when the oM changes are made
         }
 
         /***************************************************/

--- a/XML_oM/GBXML/Campus/Building.cs
+++ b/XML_oM/GBXML/Campus/Building.cs
@@ -39,7 +39,7 @@ namespace BH.oM.XML
         [XmlElement("StreetAddress")]
         public string StreetAddress { get; set; } = "Unknown";
         [XmlElement("Area")]
-        public float Area { get; set; } = 0;
+        public double Area { get; set; } = 0;
         [XmlElement("Space")]
         public List<Space> Space { get; set; } = new List<Space>();
         [XmlElement("BuildingStorey")]


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #233 
Fixes #235 
Fixes #236 
Fixes #237 

Fixes a number of small issues with XML Export, mostly on area output


 ### Test files
See existing scripts for producing XML output


 ### Changelog
#### Added
 - Added height/width checks for rectangular geometry
 - Added area export for Building
#### Fixed
 - Fixed CADObjectID export for spaces

 ### Additional comments
The Space CAD Object ID is taken from the adjacent space ID, wrapped in brackets `[ ]` as standard. Family/Type name not included because Family/Type name not available in that export option. This will be revisited after oM changes in the future.