### PR TITLE
XML_Toolkit: Space ID contains invalid characters

### DIFF
--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -198,7 +198,7 @@ namespace BH.Adapter.XML
 
                 BH.oM.XML.Space xmlSpace = new oM.XML.Space();
                 xmlSpace.Name = space.ConnectedSpaceName();
-                xmlSpace.ID = "Space-" + xmlSpace.Name;
+                xmlSpace.ID = "Space" + xmlSpace.Name.Replace("-", "");
                 xmlSpace.CADObjectID = BH.Engine.XML.Query.CADObjectID(space);
                 xmlSpace.ShellGeometry.ClosedShell.PolyLoop = BH.Engine.XML.Query.ClosedShellGeometry(space).ToArray();
                 xmlSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);

--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -198,7 +198,7 @@ namespace BH.Adapter.XML
 
                 BH.oM.XML.Space xmlSpace = new oM.XML.Space();
                 xmlSpace.Name = space.ConnectedSpaceName();
-                xmlSpace.ID = "Space" + xmlSpace.Name.Replace("-", "");
+                xmlSpace.ID = "Space" + xmlSpace.Name.Replace(" ", "").Replace("-", "");
                 xmlSpace.CADObjectID = BH.Engine.XML.Query.CADObjectID(space);
                 xmlSpace.ShellGeometry.ClosedShell.PolyLoop = BH.Engine.XML.Query.ClosedShellGeometry(space).ToArray();
                 xmlSpace.ShellGeometry.ID = "SpaceShellGeometry-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 10);

--- a/XML_Engine/Query/AdjacentSpace.cs
+++ b/XML_Engine/Query/AdjacentSpace.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.XML
         public static BHX.AdjacentSpaceId AdjacentSpaceID(this List<BHE.Panel> space)
         {
             BHX.AdjacentSpaceId adjId = new BHX.AdjacentSpaceId();
-            adjId.SpaceIDRef = "Space" + space.ConnectedSpaceName().Replace("-", "");
+            adjId.SpaceIDRef = "Space" + space.ConnectedSpaceName().Replace(" ", "").Replace("-", "");
             return adjId;
         }
     }

--- a/XML_Engine/Query/AdjacentSpace.cs
+++ b/XML_Engine/Query/AdjacentSpace.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.XML
         public static BHX.AdjacentSpaceId AdjacentSpaceID(this List<BHE.Panel> space)
         {
             BHX.AdjacentSpaceId adjId = new BHX.AdjacentSpaceId();
-            adjId.SpaceIDRef = "Space-" + space.ConnectedSpaceName();
+            adjId.SpaceIDRef = "Space" + space.ConnectedSpaceName().Replace("-", "");
             return adjId;
         }
     }


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #258 

Removes current known invalid characters from a `SpaceID`


 ### Test files
Current test files/scripts


 ### Changelog
#### Fixed
 - Fixed invalid characters in space IDs