### PR TITLE
XML_Toolkit: Push panels with no adjacencies

### DIFF
--- a/XML_Adapter/XMLSerializer.cs
+++ b/XML_Adapter/XMLSerializer.cs
@@ -80,7 +80,7 @@ namespace BH.Adapter.XML
                 SerializeLevels(dbBroken.Levels, dbBroken.ElementsAsSpaces, gbx, exportType);
                 SerializeCollection(dbBroken.ElementsAsSpaces, dbBroken.Levels, dbBroken.UnassignedPanels, gbx, exportType);
                 SerializeCollection(dbBroken.ShadingElements, gbx, exportType);
-                //SerializeCollection(dbBroken.UnassignedPanels, gbx, exportType);
+                SerializeCollection(dbBroken.UnassignedPanels, gbx, exportType); //Serialise unassigned panels as shading as an interim measure
             }
         }
 

--- a/XML_Adapter/XMLSerializer.cs
+++ b/XML_Adapter/XMLSerializer.cs
@@ -78,8 +78,9 @@ namespace BH.Adapter.XML
 
                 BH.oM.XML.Environment.DocumentBuilder dbBroken = (BH.oM.XML.Environment.DocumentBuilder)BH.Engine.Serialiser.Convert.FromBson(bd);
                 SerializeLevels(dbBroken.Levels, dbBroken.ElementsAsSpaces, gbx, exportType);
-                SerializeCollection(dbBroken.ElementsAsSpaces, dbBroken.Levels, dbBroken.Openings, gbx, exportType);
+                SerializeCollection(dbBroken.ElementsAsSpaces, dbBroken.Levels, dbBroken.UnassignedPanels, gbx, exportType);
                 SerializeCollection(dbBroken.ShadingElements, gbx, exportType);
+                //SerializeCollection(dbBroken.UnassignedPanels, gbx, exportType);
             }
         }
 
@@ -88,7 +89,7 @@ namespace BH.Adapter.XML
             foreach (BH.oM.XML.Environment.DocumentBuilder db in documents)
             {
                 SerializeLevels(db.Levels, db.ElementsAsSpaces, gbx, exportType);
-                SerializeCollection(db.ElementsAsSpaces.ExternalElements(), db.Levels, db.Openings, gbx, exportType);
+                SerializeCollection(db.ElementsAsSpaces.ExternalElements(), db.Levels, db.UnassignedPanels, gbx, exportType);
                 SerializeCollection(db.ShadingElements, gbx, exportType);
             }
         }
@@ -113,7 +114,7 @@ namespace BH.Adapter.XML
                             spaceName = "Space-" + Guid.NewGuid().ToString().Replace("-", "");
 
                         GBXML gbx = new GBXML();
-                        SerializeCollection(space, db.Levels, db.Openings, gbx, exportType);
+                        SerializeCollection(space, db.Levels, db.UnassignedPanels, gbx, exportType);
 
                         //Document History
                         DocumentHistory DocumentHistory = new DocumentHistory();

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -72,7 +72,7 @@ namespace BH.Engine.XML
             gbConstruction.Absorptance = construction.ToGBXMLAbsorptance();
             gbConstruction.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
             gbConstruction.Roughness = construction.Roughness().ToGBXML();
-            gbConstruction.UValue.Value = (analysisProperties == null ? construction.UValue() : analysisProperties.UValue).ToString();
+            gbConstruction.UValue.Value = (analysisProperties == null || analysisProperties.UValue == 0 ? construction.UValue() : analysisProperties.UValue).ToString();
 
             return gbConstruction;
         }

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -86,7 +86,7 @@ namespace BH.Engine.XML
 
             window.ID = "window-" + (contextProperties == null ? construction.Name.CleanName() : contextProperties.TypeName.CleanName());
             window.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
-            window.UValue.Value = (extraProperties == null ? "0" : extraProperties.UValue.ToString());
+            window.UValue.Value = (extraProperties == null || extraProperties.UValue == 0 ? construction.UValue().ToString() : extraProperties.UValue.ToString());
             window.Transmittance.Value = (extraProperties == null ? "0" : extraProperties.LTValue.ToString());
             window.SolarHeatGainCoefficient.Value = (extraProperties == null ? "0" : extraProperties.GValue.ToString());
             if (construction.Layers.Count > 0)

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.XML
             gbMaterial.ID = "material-" + layer.Material.Name.CleanName();
             gbMaterial.Name = layer.Material.Name;
             gbMaterial.RValue.Value = rValue.ToString();
-            gbMaterial.Thickness = Math.Round(layer.Thickness, 3);
+            gbMaterial.Thickness.Value = Math.Round(layer.Thickness, 3).ToString();
             gbMaterial.Density.Value = Math.Round(layer.Material.Density, 3).ToString();
 
             IEnvironmentMaterial envMaterial = layer.Material.Properties.Where(x => x is IEnvironmentMaterial).FirstOrDefault() as IEnvironmentMaterial;

--- a/XML_Engine/Create/DocumentBuilder.cs
+++ b/XML_Engine/Create/DocumentBuilder.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static DocumentBuilder DocumentBuilder(List<Building> building, List<List<Panel>> elementsAsSpaces, List<Panel> shadingElements, List<BH.oM.Architecture.Elements.Level> levels, List<Panel> openings)
+        public static DocumentBuilder DocumentBuilder(List<Building> building, List<List<Panel>> elementsAsSpaces, List<Panel> shadingElements, List<BH.oM.Architecture.Elements.Level> levels, List<Panel> unassignedPanels)
         {
             return new DocumentBuilder
             {
@@ -48,7 +48,7 @@ namespace BH.Engine.XML
                 ElementsAsSpaces = elementsAsSpaces,
                 ShadingElements = shadingElements,
                 Levels = levels,
-                Openings = openings,
+                UnassignedPanels = unassignedPanels,
             };         
         }
 
@@ -59,14 +59,15 @@ namespace BH.Engine.XML
             List<Level> levels = objs.Levels();
             List<Building> buildings = objs.Buildings();
 
-            List<Panel> openings = new List<Panel>();
+            List<Panel> unassignedPanels = new List<Panel>();
 
             List<Panel> shadingElements = panels.PanelsByType(PanelType.Shade);
             panels = panels.PanelsNotByType(PanelType.Shade); //Remove shading if it exists
 
             List<List<Panel>> elementsAsSpaces = panels.ToSpaces();
+            unassignedPanels.AddRange(panels.Where(x => !elementsAsSpaces.IsContaining(x)).ToList());
 
-            return DocumentBuilder(buildings, elementsAsSpaces, shadingElements, levels, openings);
+            return DocumentBuilder(buildings, elementsAsSpaces, shadingElements, levels, unassignedPanels);
         }
     }
 }

--- a/XML_oM/DocumentBuilder.cs
+++ b/XML_oM/DocumentBuilder.cs
@@ -37,7 +37,7 @@ namespace BH.oM.XML.Environment
         public List<List<BHoME.Panel>> ElementsAsSpaces { get; set; } = new List<List<BHoME.Panel>>();
         public List<BHoME.Panel> ShadingElements { get; set; } = new List<BHoME.Panel>();
         public List<BH.oM.Architecture.Elements.Level> Levels { get; set; } = new List<Architecture.Elements.Level>();
-        public List<BHoME.Panel> Openings { get; set; } = new List<BHoME.Panel>();
+        public List<BHoME.Panel> UnassignedPanels { get; set; } = new List<BHoME.Panel>();
 
         /***************************************************/
     }

--- a/XML_oM/GBXML/Materials/Material.cs
+++ b/XML_oM/GBXML/Materials/Material.cs
@@ -39,7 +39,7 @@ namespace BH.oM.XML
         [XmlElement("R-value")]
         public RValue RValue { get; set; } = new RValue();
         [XmlElement("Thickness")]
-        public double Thickness { get; set; } = 0.001;
+        public Thickness Thickness { get; set; } = new Thickness();
         [XmlElement("Conductivity")]
         public Conductivity Conductivity { get; set; } = new Conductivity();
         [XmlElement("Density")]


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #266 


 ### Test files
Current tests


 ### Changelog
#### Changed
 - Changed to allow panels (surfaces) with no adjacent spaces but aren't shading elements to be pushed as if they are shading elements - this allows them to appear in other XML fixing tools where necessary.
