### PR TITLE
XML_Toolkit: Protection against null constructions

### DIFF
--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -80,11 +80,11 @@ namespace BH.Adapter.XML
                 if (familyName == "System Panel") //No SAM_BuildingElementType for this one atm
                     gbOpening.OpeningType = "FixedWindow";
 
-                if (exportType == ExportType.gbXMLIES && gbOpening.OpeningType.Contains("Window") && opening.OpeningConstruction.Name.Contains("SLD")) //Change windows with SLD construction into doors for IES
+                if (exportType == ExportType.gbXMLIES && gbOpening.OpeningType.Contains("Window") && (opening.OpeningConstruction != null && opening.OpeningConstruction.Name.Contains("SLD"))) //Change windows with SLD construction into doors for IES
                     gbOpening.OpeningType = "NonSlidingDoor";
 
                 if (exportType == ExportType.gbXMLIES)
-                    gbOpening.WindowTypeIDRef = "window-" + (contextProperties == null? opening.OpeningConstruction.Name.CleanName() : contextProperties.TypeName.CleanName());
+                    gbOpening.WindowTypeIDRef = "window-" + (contextProperties != null? contextProperties.TypeName.CleanName() : (opening.OpeningConstruction != null ? opening.OpeningConstruction.Name.CleanName() : "" ));
                 else
                     gbOpening.WindowTypeIDRef = null;
 

--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -171,7 +171,7 @@ namespace BH.Adapter.XML
 
                     usedBEs.Add(space[x]);
 
-                    if (exportType == ExportType.gbXMLIES)
+                    if (exportType == ExportType.gbXMLIES && space[x].Construction != null)
                     {
                         BH.oM.XML.Construction conc = space[x].ToGBXMLConstruction();
                         BH.oM.XML.Construction test = usedConstructions.Where(y => y.ID == conc.ID).FirstOrDefault();

--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -162,7 +162,7 @@ namespace BH.Adapter.XML
                                 nameCheck = o.OpeningConstruction.Name;
                             
                             var t = usedWindows.Where(a => a.Name == nameCheck).FirstOrDefault();
-                            if (t == null)
+                            if (t == null && o.OpeningConstruction != null)
                                 usedWindows.Add(o.OpeningConstruction.ToGBXMLWindow(o));
                         }
                     }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #272 


 ### Test files
Rhino to BHoM script available [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/XML_Toolkit/Issue%20272%20Test%20Script?csf=1&e=5zqH7T)


 ### Changelog
#### Fixed
 - Fixed construction serialisation protection


 ### Additional comments
Fixed for panels and openings as required