### PR TITLE
XML_Toolkit: Default CADObjectID

### DIFF
--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.XML
 
             BHP.OriginContextFragment contextProperties = element.FindFragment<BHP.OriginContextFragment>(typeof(BHP.OriginContextFragment));
 
-            if (contextProperties != null)
+            if (contextProperties != null && contextProperties.ElementID != "")
             {
                 // change only Basic Wall and keep Curtain as it is
                 if (exportType == ExportType.gbXMLIES && element.Name.Contains("GLZ") && (element.Name.Contains("Basic Wall") || element.Name.Contains("Floor") || element.Name.Contains("Roof")))

--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -55,6 +55,59 @@ namespace BH.Engine.XML
 
                 CADObjectID = element.Name + " [" + contextProperties.ElementID + "]";
             }
+            else
+            {
+                //Use a default object ID
+                switch(element.Type)
+                {
+                    case BHE.PanelType.Ceiling:
+                        CADObjectID += "Compound Ceiling: SIM_INT_SLD";
+                        break;
+                    case BHE.PanelType.CurtainWall:
+                        if (element.ConnectedSpaces.Count == 2)
+                            CADObjectID += "Curtain Wall: SIM_INT_GLZ";
+                        else
+                            CADObjectID += "Curtain Wall: SIM_EXT_GLZ";
+                        break;
+                    case BHE.PanelType.Floor:
+                    case BHE.PanelType.FloorInternal:
+                        CADObjectID += "Floor: SIM_INT_SLD";
+                        break;
+                    case BHE.PanelType.FloorExposed:
+                    case BHE.PanelType.FloorRaised:
+                        CADObjectID += "Floor: SIM_EXT_SLD";
+                        break;
+                    case BHE.PanelType.Roof:
+                        CADObjectID += "Basic Roof: SIM_EXT_SLD";
+                        break;
+                    case BHE.PanelType.Shade:
+                        CADObjectID += "Basic Roof: SIM_EXT_SHD_Roof";
+                        break;
+                    case BHE.PanelType.SlabOnGrade:
+                        CADObjectID += "Floor: SIM_EXT_GRD";
+                        break;
+                    case BHE.PanelType.UndergroundCeiling:
+                        CADObjectID += "Floor: SIM_INT_SLD_Parking";
+                        break;
+                    case BHE.PanelType.UndergroundSlab:
+                        CADObjectID += "Floor: SIM_EXT_GRD";
+                        break;
+                    case BHE.PanelType.UndergroundWall:
+                        CADObjectID += "Basic Wall: SIM_EXT_GRD";
+                        break;
+                    case BHE.PanelType.Wall:
+                    case BHE.PanelType.WallExternal:
+                        CADObjectID += "Basic Wall: SIM_EXT_SLD";
+                        break;
+                    case BHE.PanelType.WallInternal:
+                        CADObjectID += "Basic Wall: SIM_INT_SLD";
+                        break;
+                    default:
+                        CADObjectID += "Undefined";
+                        break;
+                }
+                CADObjectID += " BHoM [000000]";
+            }
 
             return CADObjectID;
         }


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #277 

 ### Test files
Rhino to BHoM script available [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/XML_Toolkit/Issue%20272%20Test%20Script?csf=1&e=5zqH7T)
Just disconnect the context fragment. That ought to do the trick.

 ### Changelog
#### Added
 - Added default BHoM specific CADObjectIDs where CADObjectIDs cannot be built from existing data.