### PR TITLE
Xml toolkit issue281 materials

### DIFF
--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -44,12 +44,12 @@ namespace BH.Engine.XML
         {
             BHX.Material gbMaterial = new BHX.Material();
 
-            double rValue = Math.Round(layer.RValue(), 3);
-            if (double.IsInfinity(rValue) || double.IsNaN(rValue)) rValue = -1; //Error
+            //double rValue = Math.Round(layer.RValue(), 3);
+            //if (double.IsInfinity(rValue) || double.IsNaN(rValue)) rValue = -1; //Error
 
             gbMaterial.ID = "material-" + layer.Material.Name.CleanName();
             gbMaterial.Name = layer.Material.Name;
-            gbMaterial.RValue.Value = rValue.ToString();
+            //gbMaterial.RValue.Value = rValue.ToString();
             gbMaterial.Thickness.Value = Math.Round(layer.Thickness, 3).ToString();
 
             IEnvironmentMaterial envMaterial = layer.Material.Properties.Where(x => x is IEnvironmentMaterial).FirstOrDefault() as IEnvironmentMaterial;

--- a/XML_Engine/Convert/Environment_oM/Material.cs
+++ b/XML_Engine/Convert/Environment_oM/Material.cs
@@ -151,6 +151,22 @@ namespace BH.Engine.XML
             gap.Thickness.Value = Math.Round(layer.Thickness, 4).ToString();
             gap.Conductivity.Value = Math.Round(gasProperties.Conductivity, 3).ToString();
 
+            switch(gasProperties.Gas)
+            {
+                case Gas.Air:
+                    gap.Gas = "Air";
+                    break;
+                case Gas.Argon:
+                    gap.Gas = "Argon";
+                    break;
+                case Gas.Krypton:
+                    gap.Gas = "Krypton";
+                    break;
+                default:
+                    gap.Gas = "Custom";
+                    break;
+            }
+
             return gap;
         }
     }

--- a/XML_oM/GBXML/Materials/Material.cs
+++ b/XML_oM/GBXML/Materials/Material.cs
@@ -36,8 +36,8 @@ namespace BH.oM.XML
         public string ID { get; set; } = "MaterialID";
         [XmlElement("Name")]
         public string Name { get; set; } = "Material";
-        [XmlElement("R-value")]
-        public RValue RValue { get; set; } = new RValue();
+        /*[XmlElement("R-value")]
+        public RValue RValue { get; set; } = new RValue();*/
         [XmlElement("Thickness")]
         public Thickness Thickness { get; set; } = new Thickness();
         [XmlElement("Conductivity")]

--- a/XML_oM/GBXML/Window/Gap.cs
+++ b/XML_oM/GBXML/Window/Gap.cs
@@ -39,10 +39,10 @@ namespace BH.oM.XML
         public string Gas { get; set; } = "Argon";
 
         [XmlElement("Name")]
-        public string Name { get; set; } = "Glazing";
+        public string Name { get; set; } = null;
 
         [XmlElement("Description")]
-        public string Description { get; set; } = "Standard Dbl Glazed";
+        public string Description { get; set; } = null;
 
         [XmlElement("Thickness")]
         public Thickness Thickness { get; set; } = new Thickness();

--- a/XML_oM/GBXML/Window/Glaze.cs
+++ b/XML_oM/GBXML/Window/Glaze.cs
@@ -37,10 +37,10 @@ namespace BH.oM.XML
         public string ID { get; set; } = "GlazingIdentification" + Guid.NewGuid().ToString().Substring(0, 5);
 
         [XmlElement("Name", Order = 1)]
-        public string Name { get; set; } = "Glazing";
+        public string Name { get; set; } = null;
 
         [XmlElement("Description", Order = 2)]
-        public string Description { get; set; } = "Standard Dbl Glazed";
+        public string Description { get; set; } = null;
 
         [XmlElement("Thickness", Order = 3)]
         public Thickness Thickness { get; set; } = new Thickness();

--- a/XML_oM/GBXML/Window/WindowType.cs
+++ b/XML_oM/GBXML/Window/WindowType.cs
@@ -33,13 +33,13 @@ namespace BH.oM.XML
     public class WindowType : GBXMLObject
     {
         [XmlAttribute("id")]
-        public string ID { get; set; } = "WindowID";
+        public string ID { get; set; } = null;
 
         [XmlElement("Name", Order = 1)]
-        public string Name { get; set; } = "WindowType";
+        public string Name { get; set; } = null;
 
         [XmlElement("Description", Order = 2)]
-        public string Description { get; set; } = "Standard Dbl Glazed";
+        public string Description { get; set; } = null;
 
         [XmlElement("U-value", Order = 3)]
         public UValue UValue { get; set; } = new UValue();
@@ -51,12 +51,12 @@ namespace BH.oM.XML
         public Transmittance Transmittance { get; set; } = new Transmittance();
 
         [XmlElement(ElementName = "Glaze", Order = 6)]
-        public Glaze InternalGlaze { get; set; } = new Glaze();
+        public Glaze InternalGlaze { get; set; } = null;
 
         [XmlElement("Gap", Order = 7)]
-        public Gap Gap { get; set; } = new Gap();
+        public Gap Gap { get; set; } = null;
 
         [XmlElement(ElementName = "Glaze", Order = 8)]
-        public Glaze ExternalGlaze { get; set; } = new Glaze();
+        public Glaze ExternalGlaze { get; set; } = null;
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #281 
Fixes #205 
Fixes #238 


 ### Test files
Current test scripts but export as IES specific file.


 ### Changelog
#### Changed
 - Changed material export to work with current IES implementations.


 ### Additional comments
IES does not import materials which contain an `RValue` attribute, despite this being valid gbXML schema. This removes that and also fixes window construction export by removing duplicated materials/default values.