### PR TITLE
XML_Toolkit: Pulling panel types and connected spaces

### DIFF
--- a/XML_Engine/Convert/Environment_oM/ElementType.cs
+++ b/XML_Engine/Convert/Environment_oM/ElementType.cs
@@ -116,5 +116,59 @@ namespace BH.Engine.XML
             }
         }
 
+        public static BHE.PanelType ToBHoMPanelType(this string type)
+        {
+            switch (type)
+            {
+                case "Ceiling":
+                    return BHE.PanelType.Ceiling;
+                case "ExposedFloor":
+                    return BHE.PanelType.FloorExposed;
+                case "InteriorFloor":
+                    return BHE.PanelType.FloorInternal;
+                case "RaisedFloor":
+                    return BHE.PanelType.FloorRaised;
+                case "Roof":
+                    return BHE.PanelType.Roof;
+                case "Shade":
+                    return BHE.PanelType.Shade;
+                case "SlabOnGrade":
+                    return BHE.PanelType.SlabOnGrade;
+                case "SolarPanel":
+                    return BHE.PanelType.SolarPanel;
+                case "UndergroundCeiling":
+                    return BHE.PanelType.UndergroundCeiling;
+                case "UndergroundSlab":
+                    return BHE.PanelType.UndergroundSlab;
+                case "UndergroundWall":
+                    return BHE.PanelType.UndergroundWall;
+                case "ExteriorWall":
+                    return BHE.PanelType.WallExternal;
+                case "InteriorWall":
+                    return BHE.PanelType.WallInternal;
+                default:
+                    return BHE.PanelType.Undefined;
+            }
+        }
+
+        public static BHE.OpeningType ToBHoMOpeningType(this string type)
+        {
+            switch (type)
+            {
+                case "NonSlidingDoor":
+                    return BHE.OpeningType.Door;
+                case "Frame":
+                    return BHE.OpeningType.Frame;
+                case "FixedWindow":
+                    return BHE.OpeningType.Window;
+                case "OperableSkylight":
+                    return BHE.OpeningType.Rooflight;
+                case "VehicleDoor":
+                    return BHE.OpeningType.VehicleDoor;
+                default:
+                    return BHE.OpeningType.Undefined;
+            }
+        }
+
     }
 }

--- a/XML_Engine/Convert/Environment_oM/Opening.cs
+++ b/XML_Engine/Convert/Environment_oM/Opening.cs
@@ -100,6 +100,8 @@ namespace BH.Engine.XML
             if (cadSplit.Length > 0)
                 opening.Name = cadSplit[0].Trim();
 
+            opening.Type = gbOpening.OpeningType.ToBHoMOpeningType();
+
             return opening;
         }
     }

--- a/XML_Engine/Convert/Environment_oM/Panel.cs
+++ b/XML_Engine/Convert/Environment_oM/Panel.cs
@@ -133,6 +133,14 @@ namespace BH.Engine.XML
                 panel.FragmentProperties.Add(envContext);
             }
 
+            panel.Type = surface.SurfaceType.ToBHoMPanelType();
+            panel.ConnectedSpaces = new List<string>();
+            if (surface.AdjacentSpaceID != null)
+            {
+                foreach (BHX.AdjacentSpaceId adjacent in surface.AdjacentSpaceID)
+                    panel.ConnectedSpaces.Add(adjacent.SpaceIDRef);
+            }
+
             return panel;
         }
     }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #286 
Fixes #287 


 ### Test files
See test script (and XML file) [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FIssue%20286%20%2D%20Pull)


 ### Changelog
#### Fixed
 - Fixed PanelType being pulled correctly when going from gbXML to BHoM
 - Fixed connected spaces being set correctly when going from gbXML to BHoM