### PR TITLE
XML_Toolkit: Pull CAD Object ID for opening if it exists

### DIFF
--- a/XML_Engine/Convert/Environment_oM/Opening.cs
+++ b/XML_Engine/Convert/Environment_oM/Opening.cs
@@ -103,6 +103,8 @@ namespace BH.Engine.XML
             {
                 BHP.OriginContextFragment envContext = new BHP.OriginContextFragment();
                 envContext.ElementID = cadSplit[1].Split(']')[0].Trim();
+                envContext.TypeName = opening.Name;
+
                 if (opening.FragmentProperties == null) opening.FragmentProperties = new List<BHP.IBHoMFragment>();
                 opening.FragmentProperties.Add(envContext);
             }

--- a/XML_Engine/Convert/Environment_oM/Opening.cs
+++ b/XML_Engine/Convert/Environment_oM/Opening.cs
@@ -99,6 +99,13 @@ namespace BH.Engine.XML
             string[] cadSplit = gbOpening.CADObjectID.Split('[');
             if (cadSplit.Length > 0)
                 opening.Name = cadSplit[0].Trim();
+            if (cadSplit.Length > 1)
+            {
+                BHP.OriginContextFragment envContext = new BHP.OriginContextFragment();
+                envContext.ElementID = cadSplit[1].Split(']')[0].Trim();
+                if (opening.FragmentProperties == null) opening.FragmentProperties = new List<BHP.IBHoMFragment>();
+                opening.FragmentProperties.Add(envContext);
+            }
 
             opening.Type = gbOpening.OpeningType.ToBHoMOpeningType();
 

--- a/XML_Engine/Convert/Environment_oM/Panel.cs
+++ b/XML_Engine/Convert/Environment_oM/Panel.cs
@@ -129,6 +129,7 @@ namespace BH.Engine.XML
             {
                 BHP.OriginContextFragment envContext = new BHP.OriginContextFragment();
                 envContext.ElementID = cadSplit[1].Split(']')[0].Trim();
+                envContext.TypeName = panel.Name;
                 if (panel.FragmentProperties == null) panel.FragmentProperties = new List<BHP.IBHoMFragment>();
                 panel.FragmentProperties.Add(envContext);
             }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #290 


 ### Test files
Existing Pull/Push files


 ### Changelog
#### Fixed
 - Fixed pulling of CAD object ID if it exists for openings