### PR TITLE
XML_Toolkit: Fix pull error when pulling from an XML file without constructions

### DIFF
--- a/XML_Adapter/CRUD/Read.cs
+++ b/XML_Adapter/CRUD/Read.cs
@@ -125,18 +125,21 @@ namespace BH.Adapter.XML
                 foreach(BHX.Surface s in gbx.Campus.Surface)
                 {
                     BHE.Panel p = s.ToBHoM();
-                    BHX.Construction c = gbx.Construction.Where(x => x.ID == s.ConstructionIDRef).FirstOrDefault();
-                    if (c != null)
+                    if (gbx.Construction != null)
                     {
-                        BHX.Layer gbLayer = gbx.Layer.Where(x => x.ID == c.LayerID.LayerIDRef).FirstOrDefault();
-                        if (gbLayer != null)
+                        BHX.Construction c = gbx.Construction.Where(x => x.ID == s.ConstructionIDRef).FirstOrDefault();
+                        if (c != null)
                         {
-
-                            List<BHX.Material> gbMaterials = gbx.Material.Where(x => gbLayer.MaterialID.Where(y => y.MaterialIDRef == x.ID).FirstOrDefault() != null).ToList();
-                            if (gbMaterials.Count > 0)
+                            BHX.Layer gbLayer = gbx.Layer.Where(x => x.ID == c.LayerID.LayerIDRef).FirstOrDefault();
+                            if (gbLayer != null)
                             {
-                                List<BHC.Layer> layers = gbMaterials.Select(x => x.ToBHoM()).ToList();
-                                p.Construction = c.ToBHoM(layers);
+
+                                List<BHX.Material> gbMaterials = gbx.Material.Where(x => gbLayer.MaterialID.Where(y => y.MaterialIDRef == x.ID).FirstOrDefault() != null).ToList();
+                                if (gbMaterials.Count > 0)
+                                {
+                                    List<BHC.Layer> layers = gbMaterials.Select(x => x.ToBHoM()).ToList();
+                                    p.Construction = c.ToBHoM(layers);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #305 


 ### Test files
[Folder here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FXML%5FToolkit%2DIssue310%2DPullConstructions) contains a GH test script and an example XML file causing the bug


 ### Changelog
#### Fixed
 - Fixed ability to pull panels without constructions if constructions did not exist within the XML file