### PR TITLE
XML_Toolkit: Fix construction ID null issue

### DIFF
--- a/XML_Engine/Query/ConstructionID.cs
+++ b/XML_Engine/Query/ConstructionID.cs
@@ -37,13 +37,15 @@ namespace BH.Engine.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string ConstructionID(this BHE.Panel element)
+        public static string ConstructionID(this BHE.Panel panel)
         {
-            return element.Construction.ConstructionID();
+            if (panel == null || panel.Construction == null) return null;
+            return panel.Construction.ConstructionID();
         }
 
         public static string ConstructionID(this BHC.IConstruction construction)
         {
+            if (construction == null) return null;
             return ConstructionID(construction as dynamic);
         }
 

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #314 

 ### Test files
Existing test files

 ### Changelog
#### Fixed
 - Fixed handling `null` constructions when querying `ConstructionID`