### PR TITLE
XML_Toolkit: Fix external curtain walls and opening CAD Object ID

### DIFF
--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -100,7 +100,8 @@ namespace BH.Adapter.XML
                         srf.ConstructionIDRef = (envContextProperties != null ? envContextProperties.TypeName.CleanName() : space[x].ConstructionID());
 
                         //If the surface is a basic Wall: SIM_EXT_GLZ so Curtain Wall after CADObjectID translation add the wall as an opening
-                        if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("GLZ") && (space[x].Type != PanelType.CurtainWall))
+                        //if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("GLZ") && (space[x].Type != PanelType.CurtainWall))
+                        if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("GLZ"))
                         {
                             List<BHG.Polyline> newOpeningBounds = new List<oM.Geometry.Polyline>();
                             if (space[x].Openings.Count > 0)
@@ -127,13 +128,17 @@ namespace BH.Adapter.XML
                             curtainWallOpening.Fragments.Add(curtainWallProperties);
 
                             space[x].Openings.Add(curtainWallOpening);
-                        }
-                        else if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ") && (space[x].Type == PanelType.CurtainWall))
-                        {
+
                             //Update the host elements element type
                             srf.SurfaceType = (adjacentSpaces.Count == 1 ? PanelType.WallExternal : PanelType.WallInternal).ToGBXML();
                             srf.ExposedToSun = BH.Engine.XML.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
                         }
+                        /*else if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ") && (space[x].Type == PanelType.CurtainWall))
+                        {
+                            //Update the host elements element type
+                            srf.SurfaceType = (adjacentSpaces.Count == 1 ? PanelType.WallExternal : PanelType.WallInternal).ToGBXML();
+                            srf.ExposedToSun = BH.Engine.XML.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
+                        }*/
                     }
                     else if (exportType == ExportType.gbXMLTAS)
                     {

--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -140,7 +140,18 @@ namespace BH.Engine.XML
             BHP.OriginContextFragment contextProp = opening.FindFragment<BHP.OriginContextFragment>(typeof(BHP.OriginContextFragment));
             if (contextProp == null) return "";
 
-            return contextProp.TypeName + " [" + contextProp.ElementID + "]";
+            string cadID = "";
+            if (contextProp.TypeName == "") cadID += "WinInst: SIM_EXT_GLZ";
+            else cadID += contextProp.TypeName;
+
+            cadID += " [";
+
+            if (contextProp.ElementID == "") cadID += "000000";
+            else cadID += contextProp.ElementID;
+
+            cadID += "]";
+
+            return cadID;
         }
 
         /***************************************************/

--- a/XML_Engine/Query/CadObjectId.cs
+++ b/XML_Engine/Query/CadObjectId.cs
@@ -138,7 +138,7 @@ namespace BH.Engine.XML
         public static string CADObjectID(this BHE.Opening opening, ExportType exportType)
         {
             BHP.OriginContextFragment contextProp = opening.FindFragment<BHP.OriginContextFragment>(typeof(BHP.OriginContextFragment));
-            if (contextProp == null) return "";
+            if (contextProp == null) return "WinInst: SIM_EXT_GLZ [000000]";
 
             string cadID = "";
             if (contextProp.TypeName == "") cadID += "WinInst: SIM_EXT_GLZ";


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #327 
Fixes #326 

 ### Test files
See issue test files


 ### Changelog
#### Fixed
 - Fixed Externally Glazed curtain wall issue


 ### Additional comments
Please review thoroughly - see code changes. We previously had it only adding openings for panels which were not of type curtain wall. Maybe something else changed that means we now need to do that, but I would like us to review fully. That's why the old code is still there just commented out just in case...

Also:
![image](https://user-images.githubusercontent.com/18049174/61362721-932a2500-a87a-11e9-8f9c-32b65c13a1ed.png)
