### PR TITLE
XML_Toolkit: Fix external air types to be correct types

### DIFF
--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -105,7 +105,6 @@ namespace BH.Adapter.XML
                     if (settings.ReplaceCurtainWalls)
                     {
                         //If the surface is a basic Wall: SIM_EXT_GLZ so Curtain Wall after CADObjectID translation add the wall as an opening
-                        //if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("GLZ") && (space[x].Type != PanelType.CurtainWall))
                         if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("GLZ"))
                         {
                             List<BHG.Polyline> newOpeningBounds = new List<oM.Geometry.Polyline>();
@@ -138,12 +137,6 @@ namespace BH.Adapter.XML
                             srf.SurfaceType = (adjacentSpaces.Count == 1 ? PanelType.WallExternal : PanelType.WallInternal).ToGBXML();
                             srf.ExposedToSun = BH.Engine.XML.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
                         }
-                        /*else if (srf.CADObjectID.Contains("Curtain") && srf.CADObjectID.Contains("Wall") && srf.CADObjectID.Contains("GLZ") && (space[x].Type == PanelType.CurtainWall))
-                        {
-                            //Update the host elements element type
-                            srf.SurfaceType = (adjacentSpaces.Count == 1 ? PanelType.WallExternal : PanelType.WallInternal).ToGBXML();
-                            srf.ExposedToSun = BH.Engine.XML.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
-                        }*/
                     }
                     else
                     {
@@ -153,7 +146,18 @@ namespace BH.Adapter.XML
                             srf.SurfaceType = (adjacentSpaces.Count == 1 ? PanelType.WallExternal : PanelType.WallInternal).ToGBXML();
                             srf.ExposedToSun = BH.Engine.XML.Query.ExposedToSun(srf.SurfaceType).ToString().ToLower();
                         }
-                    }                   
+                    }
+                    
+                    if(settings.FixIncorrectAirTypes && space[x].Type == PanelType.Undefined && space[x].ConnectedSpaces.Count == 1)
+                    {
+                        //Fix external air types
+                        if (space[x].Tilt() == 0)
+                            srf.SurfaceType = PanelType.Roof.ToGBXML();
+                        else if (space[x].Tilt() == 90)
+                            srf.SurfaceType = PanelType.WallExternal.ToGBXML();
+                        else if (space[x].Tilt() == 180)
+                            srf.SurfaceType = PanelType.SlabOnGrade.ToGBXML();
+                    }           
 
                     //Openings
                     if (space[x].Openings.Count > 0)

--- a/XML_Engine/Create/XMLSettings.cs
+++ b/XML_Engine/Create/XMLSettings.cs
@@ -44,17 +44,19 @@ namespace BH.Engine.XML
         [Input("replaceCurtainWalls", "Set to true if you want to replace curtain walls to have openings the same size as the wall. This is useful for IES exports. Default false")]
         [Input("replaceSolidOpeningsIntoDoors", "Set to true if you want to replace an opening which is marked as solid into a door. Useful for IES exports. Default false")]
         [Input("includeConstructions", "Set to true if you want to include construction and material data in the export. Default false")]
+        [Input("fixIncorrectAirTypes", "Set to true if you want air types with one adjacent space (i.e. external air walls) to have their type fixed based on their tilt. Default false")]
         [Input("newFile", "Set to false if you want to append to a file when pushing XML. If set to true then a file will be created. If a file exists, it will be overwritten. Default true")]
         [Input("unitType", "Set the unit type for the export to be either SI or Imperial. Default SI")]
         [Input("exportDetail", "Set the detail of your export to be either full (whole building), shell (exterior walls only), or spaces (each individual space as its own XML file). Default full")]
         [Output("xmlSettings", "The XML settings to use with the XML adapter push")]
-        public static XMLSettings XMLSettings(bool replaceCurtainWalls = false, bool replaceSolidOpeningsIntoDoors = false, bool includeConstructions = false, bool newFile = true, UnitType unitType = UnitType.SI, ExportDetail exportDetail = ExportDetail.Full)
+        public static XMLSettings XMLSettings(bool replaceCurtainWalls = false, bool replaceSolidOpeningsIntoDoors = false, bool includeConstructions = false, bool fixIncorrectAirTypes = false, bool newFile = true, UnitType unitType = UnitType.SI, ExportDetail exportDetail = ExportDetail.Full)
         {
             return new XMLSettings
             {
                 ReplaceCurtainWalls = replaceCurtainWalls,
                 ReplaceSolidOpeningsIntoDoors = replaceSolidOpeningsIntoDoors,
                 IncludeConstructions = includeConstructions,
+                FixIncorrectAirTypes = fixIncorrectAirTypes,
                 NewFile = newFile,
                 UnitType = unitType,
                 ExportDetail = exportDetail,

--- a/XML_oM/XMLSettings.cs
+++ b/XML_oM/XMLSettings.cs
@@ -36,6 +36,7 @@ namespace BH.oM.XML.Settings
         public bool ReplaceCurtainWalls { get; set; } = false;
         public bool ReplaceSolidOpeningsIntoDoors { get; set; } = false;
         public bool IncludeConstructions { get; set; } = false;
+        public bool FixIncorrectAirTypes { get; set; } = false;
         public bool NewFile { get; set; } = true;
         public UnitType UnitType { get; set; } = UnitType.SI;
         public ExportDetail ExportDetail { get; set; } = ExportDetail.Full;

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -105,7 +105,7 @@
     <Compile Include="GBXML\Window\WindowType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GBXML\Zone\Zone.cs" />
-    <Compile Include="Settings.cs" />
+    <Compile Include="XMLSettings.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #294 


 ### Test files
See [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FIssue%20294%20%2D%20air%20types)

Included are a GH script which will pull from an XML file (provided), then push to a new XML file (not provided) using the new setting to fix air walls, and then repull that file to demonstrate changes in `undefined` panel types.

 ### Changelog
 - Fix external air types to be a more correct type. Included on XML Settings for user preference