### PR TITLE
Update references to Level from Architecture to Geometry.SettingOut

### DIFF
--- a/XML_Adapter/CRUD/Read.cs
+++ b/XML_Adapter/CRUD/Read.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.XML
                 return ReadConstructions(gbx);
             else if (type == typeof(BH.oM.Physical.Properties.Material))
                 return ReadMaterials(gbx);*/
-            else if (type == typeof(BHA.Level))
+            else if (type == typeof(BHG.SettingOut.Level))
                 return ReadLevels(gbx);
             else
                 return ReadFullXMLFile(gbx);            
@@ -189,12 +189,12 @@ namespace BH.Adapter.XML
                 return new List<BH.oM.Environment.Materials.Material>();
         }*/
 
-        private List<BHA.Level> ReadLevels(BHX.GBXML gbx, List<string> ids = null)
+        private List<BHG.SettingOut.Level> ReadLevels(BHX.GBXML gbx, List<string> ids = null)
         {
             if (gbx.Campus.Building.Length > 0)
                 return gbx.Campus.Building[0].BuildingStorey.Select(x => x.ToBHoM()).ToList();
             else
-                return new List<BHA.Level>();
+                return new List<BHG.SettingOut.Level>();
         }
     }
 }

--- a/XML_Adapter/Serialise/Level.cs
+++ b/XML_Adapter/Serialise/Level.cs
@@ -44,11 +44,11 @@ namespace BH.Adapter.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static void SerializeLevels(List<BH.oM.Architecture.Elements.Level> levels, List<List<Panel>> spaces, BH.oM.XML.GBXML gbx, XMLSettings settings)
+        public static void SerializeLevels(List<BH.oM.Geometry.SettingOut.Level> levels, List<List<Panel>> spaces, BH.oM.XML.GBXML gbx, XMLSettings settings)
         {
             List<BH.oM.XML.BuildingStorey> xmlLevels = new List<BuildingStorey>();
 
-            foreach(BH.oM.Architecture.Elements.Level level in levels)
+            foreach(BH.oM.Geometry.SettingOut.Level level in levels)
             {
                 string levelName = "";
                 if (level.Name == "")

--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -31,9 +31,8 @@ using BH.oM.XML;
 using BH.Engine.XML;
 
 using BHG = BH.oM.Geometry;
+using BH.oM.Geometry.SettingOut;
 using BH.Engine.Geometry;
-
-using BH.oM.Architecture.Elements;
 
 using BH.oM.XML.Enums;
 

--- a/XML_Engine/Convert/Architecture_oM/Level.cs
+++ b/XML_Engine/Convert/Architecture_oM/Level.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.XML
 {
     public static partial class Convert
     {
-        public static BHX.BuildingStorey ToGBXML(this BHA.Level level, List<List<BHE.Panel>> spaces = null)
+        public static BHX.BuildingStorey ToGBXML(this BHG.SettingOut.Level level, List<List<BHE.Panel>> spaces = null)
         {
             BHX.BuildingStorey storey = new BHX.BuildingStorey();
 
@@ -57,9 +57,9 @@ namespace BH.Engine.XML
             return storey;
         }
 
-        public static BHA.Level ToBHoM(this BHX.BuildingStorey storey)
+        public static BHG.SettingOut.Level ToBHoM(this BHX.BuildingStorey storey)
         {
-            BHA.Level level = new BHA.Level();
+            BHG.SettingOut.Level level = new BHG.SettingOut.Level();
 
             level.Name = storey.Name;
             level.Elevation = storey.Level;

--- a/XML_Engine/Create/DocumentBuilder.cs
+++ b/XML_Engine/Create/DocumentBuilder.cs
@@ -25,11 +25,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Reflection.Attributes;
 
 using BH.oM.Environment.Elements;
 using BH.oM.XML.Environment;
 using BH.oM.Base;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.Engine.Environment;
 
 namespace BH.Engine.XML
@@ -40,7 +41,7 @@ namespace BH.Engine.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static DocumentBuilder DocumentBuilder(List<Building> building, List<List<Panel>> elementsAsSpaces, List<Panel> shadingElements, List<BH.oM.Architecture.Elements.Level> levels, List<Panel> unassignedPanels)
+        public static DocumentBuilder DocumentBuilder(List<Building> building, List<List<Panel>> elementsAsSpaces, List<Panel> shadingElements, List<Level> levels, List<Panel> unassignedPanels)
         {
             return new DocumentBuilder
             {
@@ -69,5 +70,51 @@ namespace BH.Engine.XML
 
             return DocumentBuilder(buildings, elementsAsSpaces, shadingElements, levels, unassignedPanels);
         }
+
+
+
+
+        /***************************************************/
+        /**** Deprecated Methods                        ****/
+        /***************************************************/
+
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static DocumentBuilder DocumentBuilder(List<Building> building, List<List<Panel>> elementsAsSpaces, List<Panel> shadingElements, List<BH.oM.Architecture.Elements.Level> levels, List<Panel> unassignedPanels)
+        {
+            return new DocumentBuilder
+            {
+                Buildings = building,
+                ElementsAsSpaces = elementsAsSpaces,
+                ShadingElements = shadingElements,
+                Levels = levels.UpgradeVersion(),
+                UnassignedPanels = unassignedPanels,
+            };
+        }
+
+
+        /******************************************/
+        /****      Level Version Converts      ****/
+        /******************************************/
+
+        [DeprecatedAttribute("2.4", "BH.oM.Architecture.Elements.Level replaced by BH.oM.Geometry.SettingOut.Level")]
+        private static List<Level> UpgradeVersion(this List<BH.oM.Architecture.Elements.Level> levels)
+        {
+            List<Level> upgradedLevels = new List<Level>();
+
+            foreach (BH.oM.Architecture.Elements.Level level in levels)
+                upgradedLevels.Add(level.UpgradeVersion());
+
+            return upgradedLevels;
+        }
+
+        /******************************************/
+
+        [DeprecatedAttribute("2.4", "BH.oM.Architecture.Elements.Level replaced by BH.oM.Geometry.SettingOut.Level")]
+        private static Level UpgradeVersion(this BH.oM.Architecture.Elements.Level level)
+        {
+            return new Level { Name = level.Name, Elevation = level.Elevation, CustomData = level.CustomData, Fragments = level.Fragments };
+        }
+
+        /******************************************/
     }
 }

--- a/XML_oM/DocumentBuilder.cs
+++ b/XML_oM/DocumentBuilder.cs
@@ -36,7 +36,7 @@ namespace BH.oM.XML.Environment
         public List<BHoME.Building> Buildings { get; set; } = new List<BHoME.Building>();
         public List<List<BHoME.Panel>> ElementsAsSpaces { get; set; } = new List<List<BHoME.Panel>>();
         public List<BHoME.Panel> ShadingElements { get; set; } = new List<BHoME.Panel>();
-        public List<BH.oM.Architecture.Elements.Level> Levels { get; set; } = new List<Architecture.Elements.Level>();
+        public List<BH.oM.Geometry.SettingOut.Level> Levels { get; set; } = new List<BH.oM.Geometry.SettingOut.Level>();
         public List<BHoME.Panel> UnassignedPanels { get; set; } = new List<BHoME.Panel>();
 
         /***************************************************/

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -39,6 +39,10 @@
     <Reference Include="Environment_oM">
       <HintPath>..\..\BHoM\Build\Environment_oM.dll</HintPath>
     </Reference>
+    <Reference Include="Geometry_oM, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/554
https://github.com/BHoM/BHoM_Engine/pull/1204



 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #346 


 ### Additional comments
<!-- As required -->
- Dependencies on `Architecture.Elements.Level` removed and replaced with `Geometry.SettingOut.Level` 
- External Create `DocumentBuilder` based on `List<BH.oM.Architecture.Elements.Level> levels` deprecated.
