### PR TITLE
U-Value protection 

### DIFF
--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -80,7 +80,7 @@ namespace BH.Engine.XML
             gbConstruction.UValue.Value = (analysisProperties == null || analysisProperties.UValue == 0 ? (construction.UValue() == double.NaN || double.IsInfinity(construction.UValue()) ? 10 : construction.UValue()) : analysisProperties.UValue).ToString();
 
             if (gbConstruction.UValue.Value == "10")
-            BH.Engine.Reflection.Compute.RecordWarning(string.Format("U-Value has been calculated to Infinity or NaN. Has been set to default 10"));
+                BH.Engine.Reflection.Compute.RecordWarning(string.Format("U-Value has been calculated to Infinity or NaN. Has been set to default 10"));
 
             return gbConstruction;
         }

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -80,7 +80,7 @@ namespace BH.Engine.XML
             gbConstruction.UValue.Value = (analysisProperties == null || analysisProperties.UValue == 0 ? (construction.UValue() == double.NaN || double.IsInfinity(construction.UValue()) ? 10 : construction.UValue()) : analysisProperties.UValue).ToString();
 
             if (gbConstruction.UValue.Value == "10")
-            BH.Engine.Reflection.Compute.RecordWarning(string.Format("U-Value has been recorded as Infinity or NaN, has been set to default 10"));
+            BH.Engine.Reflection.Compute.RecordWarning(string.Format("U-Value has been calculated to Infinity or NaN. Has been set to default 10"));
 
             return gbConstruction;
         }

--- a/XML_Engine/Convert/Environment_oM/Construction.cs
+++ b/XML_Engine/Convert/Environment_oM/Construction.cs
@@ -77,7 +77,10 @@ namespace BH.Engine.XML
             gbConstruction.Absorptance.Value = construction.Absorptance().ToString();
             gbConstruction.Name = (contextProperties == null ? construction.Name : contextProperties.TypeName);
             gbConstruction.Roughness = construction.Roughness().ToGBXML();
-            gbConstruction.UValue.Value = (analysisProperties == null || analysisProperties.UValue == 0 ? construction.UValue() : analysisProperties.UValue).ToString();
+            gbConstruction.UValue.Value = (analysisProperties == null || analysisProperties.UValue == 0 ? (construction.UValue() == double.NaN || double.IsInfinity(construction.UValue()) ? 10 : construction.UValue()) : analysisProperties.UValue).ToString();
+
+            if (gbConstruction.UValue.Value == "10")
+            BH.Engine.Reflection.Compute.RecordWarning(string.Format("U-Value has been recorded as Infinity or NaN, has been set to default 10"));
 
             return gbConstruction;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #358 

U-Values are sometimes calculated to Infinity or NaN. If this happens value is now set to a default of 10 and a warning occurs on the push. 


 ### Test files
[Test files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=HbjegC&cid=f4c64dc1%2D6aae%2D48c8%2Db90c%2Dca7bf4d25656&RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FXML%5FToolkit%2DIssue358%5FConstruction&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->