### PR TITLE
Align to changes in BHoM Adapter

### DIFF
--- a/XML_Adapter/CRUD/Create.cs
+++ b/XML_Adapter/CRUD/Create.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.XML
 {
     public partial class XMLAdapter : BHoMAdapter
     {
-        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
+        protected override bool Create<T>(IEnumerable<T> objects)
         {
             string fileName = _fileSettings.FullFileName();
 

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -57,9 +57,7 @@ namespace BH.Adapter.XML
             _xmlSettings = xmlSettings;
 
             AdapterId = "XML_Adapter";
-            Config.MergeWithComparer = false;   //Set to true after comparers have been implemented
             Config.ProcessInMemory = false;
-            Config.SeparateProperties = false;  //Set to true after Dependency types have been implemented
             Config.UseAdapterId = false;        //Set to true when NextId method and id tagging has been implemented
         }
 
@@ -78,7 +76,7 @@ namespace BH.Adapter.XML
             {
                 MethodInfo mInfo = methodInfos.MakeGenericMethod(new[] { typeGroup.Key });
                 var list = mInfo.Invoke(typeGroup, new object[] { typeGroup });
-                success &= Create(list as dynamic, false);
+                success &= Create(list as dynamic);
             }
 
             return success ? objects.ToList() : new List<IObject>();

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -57,7 +57,6 @@ namespace BH.Adapter.XML
             _xmlSettings = xmlSettings;
 
             AdapterId = "XML_Adapter";
-            Config.ProcessInMemory = false;
             Config.UseAdapterId = false;        //Set to true when NextId method and id tagging has been implemented
         }
 

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,4 +1,4 @@
 # XML_Toolkit REPO CODEOWNERS
 
 # default global
-* @FraserGreenroyd
+* @FraserGreenroyd @tg359


### PR DESCRIPTION
### NOTE: Depends on 
https://github.com/BHoM/BHoM_Adapter/pull/151
https://github.com/BHoM/BHoM_UI/pull/149

   - If testing on Grasshopper, you need [Grasshopper_Toolkit branch](https://github.com/BHoM/Grasshopper_Toolkit)
   - If testing on Dynamo, you need [Dynamo_Toolkit branch](https://github.com/BHoM/Dynamo_Toolkit/pull/178)
   - If testing on Excel_Toolkit, you need [Excel_Toolkit branch](https://github.com/BHoM/Excel_Toolkit/pull/163)

   - If your Toolkit uses Socket_Toolkit: [Socket_Toolkit branch](https://github.com/BHoM/Socket_Toolkit/tree/BHoM_Adapter-refactoringLvl3-01)
   - If your Toolkit uses Mongo_Toolkit: [Mongo_Toolkit branch](https://github.com/BHoM/Mongo_Toolkit/tree/BHoM_Adapter-refactoringLvl3-01)

 ### Issues addressed by this PR

 Closes #369 


Updating adapter to align with changes in the parent BHoMAdapter

 ### Test files
<!-- Link to test files to validate the proposed changes -->

All previous scripts should still be working as before.
