### PR TITLE
XML_Toolkit Push warning for Tilt

### DIFF
--- a/XML_Engine/Convert/Environment_oM/Panel.cs
+++ b/XML_Engine/Convert/Environment_oM/Panel.cs
@@ -111,7 +111,7 @@ namespace BH.Engine.XML
             if (geom.Width == 0)
                 geom.Width = Math.Round(element.Area() / geom.Height, 3);
             if (geom.Tilt == -1)
-                BH.Engine.Reflection.Compute.RecordWarning("Hej");
+                BH.Engine.Reflection.Compute.RecordWarning("Warning, Tilt has been calculated to -1 for one or more panels.");
 
             return geom;
         }

--- a/XML_Engine/Convert/Environment_oM/Panel.cs
+++ b/XML_Engine/Convert/Environment_oM/Panel.cs
@@ -111,7 +111,7 @@ namespace BH.Engine.XML
             if (geom.Width == 0)
                 geom.Width = Math.Round(element.Area() / geom.Height, 3);
             if (geom.Tilt == -1)
-                BH.Engine.Reflection.Compute.RecordWarning("Warning, Tilt has been calculated to -1 for one or more panels.");
+                BH.Engine.Reflection.Compute.RecordWarning("Warning, panel " + element.BHoM_Guid + " has been calculated to have a tilt of -1.");
 
             return geom;
         }

--- a/XML_Engine/Convert/Environment_oM/Panel.cs
+++ b/XML_Engine/Convert/Environment_oM/Panel.cs
@@ -110,6 +110,8 @@ namespace BH.Engine.XML
                 geom.Height = Math.Round(element.Area() / geom.Width, 3);
             if (geom.Width == 0)
                 geom.Width = Math.Round(element.Area() / geom.Height, 3);
+            if (geom.Tilt == -1)
+                BH.Engine.Reflection.Compute.RecordWarning("Hej");
 
             return geom;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #357 

Will compute a warning when pushing if any panel has a tilt = -1.


 ### Test files
[Test files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FXML%5FToolkit%2DIssue357%5FPush%2DWarnings)


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->