### PR TITLE
BuildingStorey ID update for IndividualSpaceExport

### DIFF
--- a/XML_Adapter/XMLSerializer.cs
+++ b/XML_Adapter/XMLSerializer.cs
@@ -20,21 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Environment;
+using BH.Engine.XML;
+using BH.oM.Base;
+using BH.oM.Environment.Elements;
+using BH.oM.XML;
+using BH.oM.XML.Enums;
+using BH.oM.XML.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using BH.oM.XML;
-using BH.oM.Base;
-using BH.oM.Environment.Elements;
-using BHP = BH.oM.Environment.Fragments;
-using BHG = BH.oM.Geometry;
-using BH.Engine.Geometry;
-using BH.Engine.Environment;
-
-using BH.Engine.XML;
-using BH.oM.XML.Enums;
-
-using BH.oM.XML.Settings;
+using BH.oM.Geometry.SettingOut;
 
 namespace BH.Adapter.XML
 {
@@ -103,7 +99,7 @@ namespace BH.Adapter.XML
 
             foreach (BH.oM.XML.Environment.DocumentBuilder db in documents)
             {
-                foreach(List<Panel> space in db.ElementsAsSpaces)
+                foreach (List<Panel> space in db.ElementsAsSpaces)
                 {
                     if (space.IsExternal(db.ElementsAsSpaces))
                     {
@@ -116,6 +112,9 @@ namespace BH.Adapter.XML
 
                         GBXML gbx = new GBXML();
                         SerializeCollection(space, db.Levels, db.UnassignedPanels, gbx, settings);
+                        Level level = space.Level(db.Levels);
+                        if (level != null)
+                            SerializeLevels(new List<Level> { level }, new List<List<Panel>>{ space }, gbx, settings);
 
                         //Document History
                         DocumentHistory DocumentHistory = new DocumentHistory();

--- a/XML_Adapter/XMLSerializer.cs
+++ b/XML_Adapter/XMLSerializer.cs
@@ -117,9 +117,9 @@ namespace BH.Adapter.XML
                             SerializeLevels(new List<Level> { level }, new List<List<Panel>>{ space }, gbx, settings);
 
                         //Document History
-                        DocumentHistory DocumentHistory = new DocumentHistory();
-                        DocumentHistory.CreatedBy.Date = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
-                        gbx.DocumentHistory = DocumentHistory;
+                        DocumentHistory documentHistory = new DocumentHistory();
+                        documentHistory.CreatedBy.Date = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
+                        gbx.DocumentHistory = documentHistory;
 
                         XMLWriter.Save(fileName + spaceName + ".xml", gbx);
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #231  

 BuildingsStory id will now show the individual story when doing an IndividualSpaceExport instead of a default "StoreyID". 


 ### Test files
Standard tests

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->