### PR TITLE
Change spaceName for shell Export

### DIFF
--- a/XML_Adapter/Serialise/Panel.cs
+++ b/XML_Adapter/Serialise/Panel.cs
@@ -341,6 +341,7 @@ namespace BH.Adapter.XML
             elementsAsSpaces.Add(inputElements.ToList());
 
             SerializeCollection(elementsAsSpaces, levels, openings, gbx, settings);
+            gbx.Campus.Building[0].Space[0].Name = "00_000 BuildingShell";
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #232 

Changed space name for shell export, from being the first space of the model to "00_000 BuildingShell"


 ### Test files
Standard tests


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->