### PR TITLE
Null item protection

### DIFF
--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -65,6 +65,8 @@ namespace BH.Adapter.XML
 
                 if (openingArea >= panelArea)
                 {
+                    if (openingPoly == null) continue;
+
                     openingPoly = BH.Engine.Geometry.Modify.Offset(openingPoly, settings.OffsetDistance);
                     gbOpening.PlanarGeometry.PolyLoop = openingPoly.ToGBXML();
                 }

--- a/XML_Adapter/Serialise/Opening.cs
+++ b/XML_Adapter/Serialise/Opening.cs
@@ -65,9 +65,9 @@ namespace BH.Adapter.XML
 
                 if (openingArea >= panelArea)
                 {
-                    if (openingPoly == null) continue;
-
                     openingPoly = BH.Engine.Geometry.Modify.Offset(openingPoly, settings.OffsetDistance);
+
+                    if (openingPoly == null) continue;
                     gbOpening.PlanarGeometry.PolyLoop = openingPoly.ToGBXML();
                 }
 


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #432 

Adds a protection for if a openingPoly returns null. 


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->