### PR TITLE
Change normal away from space calculation to use first connected space only

### DIFF
--- a/XML_Adapter/Convert/GBXML/Environment/Panel.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Panel.cs
@@ -81,7 +81,7 @@ namespace BH.Adapter.XML
             surface.RectangularGeometry = geom;
 
             BHG.Polyline pLine = panel.Polyline();
-            if(space != null && !pLine.NormalAwayFromSpace(space, settings.PlanarTolerance))
+            if(space != null && panel.ConnectedSpaces[0] == space.ConnectedSpaceName() && !pLine.NormalAwayFromSpace(space, settings.PlanarTolerance))
             {
                 pLine = pLine.Flip();
                 surface.PlanarGeometry.PolyLoop = pLine.ToGBXML();


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #444 

 ### Test files
See issue/standard test scripts

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
The number of errors in TAS is reduced down to just 2 so this should be an improvement providing it does not break any IES workflows.