### PR TITLE
Change KML polygon conversion to handle triangular mesh faces

### DIFF
--- a/XML_Adapter/Convert/KML/Mesh.cs
+++ b/XML_Adapter/Convert/KML/Mesh.cs
@@ -44,7 +44,10 @@ namespace BH.Adapter.XML
                     mesh.Vertices[face.C].DeepClone(),
                     mesh.Vertices[face.A].DeepClone()
                 };
-                if (face.D > -1) points.Insert(3, mesh.Vertices[face.D].DeepClone());
+
+                if (face.D > -1)
+                    points.Insert(3, mesh.Vertices[face.D].DeepClone());
+
                 foreach (BHG.Point p in points)
                 {
                     BHG.Point kmlpoint = p.ToLatLon(geoReference);

--- a/XML_Adapter/Convert/KML/Mesh.cs
+++ b/XML_Adapter/Convert/KML/Mesh.cs
@@ -42,9 +42,9 @@ namespace BH.Adapter.XML
                     mesh.Vertices[face.A].DeepClone(),
                     mesh.Vertices[face.B].DeepClone(),
                     mesh.Vertices[face.C].DeepClone(),
-                    mesh.Vertices[face.D].DeepClone(),
                     mesh.Vertices[face.A].DeepClone()
                 };
+                if (face.D > -1) points.Insert(3, mesh.Vertices[face.D].DeepClone());
                 foreach (BHG.Point p in points)
                 {
                     BHG.Point kmlpoint = p.ToLatLon(geoReference);


### PR DESCRIPTION
 ### Issues addressed by this PR

 Closes #463 
 Conversion from BHoM Mesh to KML Polygon list now handles quad and triangular mesh faces.

 ### Test files
[MeshFaceTests.zip](https://github.com/BHoM/XML_Toolkit/files/4632945/MeshFaceTests.zip)