### PR TITLE
Fix Space perimeter pulling for gbXML files with no SpacePlanarGeometry

### DIFF
--- a/XML_Adapter/CRUD/GBXML/ReadGBXML.cs
+++ b/XML_Adapter/CRUD/GBXML/ReadGBXML.cs
@@ -103,20 +103,13 @@ namespace BH.Adapter.XML
                 {
                     foreach (BHX.Space space in b.Space)
                     {
-                        BHE.Space bhomS = new oM.Environment.Elements.Space();
-                        bhomS.Name = space.Name;
-                        bhomS.Perimeter = space.PlanarGeoemtry.PolyLoop.FromGBXML();
-
-                        if(bhomS.Perimeter.IControlPoints().Count == 1)
+                        BHE.Space bhomS = space.FromGBXML();
+                        if (bhomS.Perimeter.IControlPoints().Count == 1)
                         {
                             //Pulling from IES probably means it's wrong...
                             List<Panel> panelsAsSpace = space.SpaceBoundary.Select(x => gbx.Campus.Surface.Where(y => y.ID == x.SurfaceIDRef).FirstOrDefault().FromGBXML()).ToList();
                             bhomS.Perimeter = panelsAsSpace.FloorGeometry();
                         }
-
-                        OriginContextFragment f = new OriginContextFragment();
-                        f.ElementID = space.ID;
-                        bhomS.Fragments.Add(f);
                         s.Add(bhomS);
                     }
                 }

--- a/XML_Adapter/Convert/GBXML/Environment/Space.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Space.cs
@@ -34,6 +34,7 @@ using BH.oM.Geometry;
 
 using BH.Engine.Geometry;
 using BH.Engine.Environment;
+using BH.oM.Environment.Fragments;
 
 namespace BH.Adapter.XML
 {
@@ -49,7 +50,7 @@ namespace BH.Adapter.XML
 
             List<Polyline> shellGeometry = panelsAsSpace.ClosedShellGeometry();
             List<GBXML.Polyloop> loopShell = new List<GBXML.Polyloop>();
-            foreach(Polyline p in shellGeometry)
+            foreach (Polyline p in shellGeometry)
             {
                 if (p.NormalAwayFromSpace(panelsAsSpace, settings.PlanarTolerance))
                     loopShell.Add(p.ToGBXML());
@@ -80,6 +81,18 @@ namespace BH.Adapter.XML
             }
 
             return xmlSpace;
+        }
+
+        public static Space FromGBXML(this GBXML.Space space, GBXMLSettings settings = null)
+        {
+            Space bhomS = new oM.Environment.Elements.Space();
+            bhomS.Name = space.Name;
+            bhomS.Perimeter = space.PlanarGeoemtry.PolyLoop.FromGBXML();
+
+            OriginContextFragment f = new OriginContextFragment();
+            f.ElementID = space.ID;
+            bhomS.Fragments.Add(f);
+            return bhomS;
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #483 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Test xml from IES.zip](https://github.com/BHoM/XML_Toolkit/files/4896331/Test.xml.from.IES.zip)


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required --> Fixes an issue typically found when handling XML files exported from IES. 