### PR TITLE
Pull of EnergyPlus Loads results

### DIFF
--- a/XML_Adapter/CRUD/Create.cs
+++ b/XML_Adapter/CRUD/Create.cs
@@ -56,6 +56,9 @@ namespace BH.Adapter.XML
                     return CreateGBXML(objects, config);
                 case Schema.KML:
                     return CreateKML(objects, config);
+                case Schema.EnergyPlusLoads:
+                    BH.Engine.Reflection.Compute.RecordError("The EnergyPlusLoads Schema is not supported for push operations at this time");
+                    return false;
                 default:
                     BH.Engine.Reflection.Compute.RecordError("The XML Schema you have supplied is not currently supported by the XML Toolkit");
                     return false;

--- a/XML_Adapter/CRUD/EnergyPlus/ReadEnergyPlus.cs
+++ b/XML_Adapter/CRUD/EnergyPlus/ReadEnergyPlus.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -24,6 +24,9 @@ using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.Xml.Serialization;
+using System.IO;
+
 using BH.oM.Base;
 using BHE = BH.oM.Environment.Elements;
 using BH.oM.Environment.Fragments;
@@ -36,40 +39,25 @@ using BHC = BH.oM.Physical.Constructions;
 
 using BH.oM.Adapter;
 using BH.Engine.Adapter;
+using BH.Engine.Geometry;
+using BH.oM.Environment.Elements;
+using BH.Engine.Environment;
 
 namespace BH.Adapter.XML
 {
     public partial class XMLAdapter : BHoMAdapter
     {
-        
-        protected override IEnumerable<IBHoMObject> IRead(Type type, IList indices = null, ActionConfig actionConfig = null)
+
+        private IEnumerable<IBHoMObject> ReadEnergyPlus(Type type = null, XMLConfig config = null)
         {
-            if (actionConfig == null)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Please provide configuration settings to push to an XML file");
-                return new List<IBHoMObject>();
-            }
+            BH.oM.XML.EnergyPlus.EnergyPlusTabularReport report = null;
 
-            XMLConfig config = actionConfig as XMLConfig;
-            if (config == null)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Please provide valid a XMLConfig object for pushing to an XML file");
-                return new List<IBHoMObject>();
-            }
+            TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+            XmlSerializer szer = new XmlSerializer(typeof(BH.oM.XML.EnergyPlus.EnergyPlusTabularReport));
+            report = (BH.oM.XML.EnergyPlus.EnergyPlusTabularReport)szer.Deserialize(reader);
+            reader.Close();
 
-            switch (config.Schema)
-            {
-                case Schema.GBXML:
-                    return ReadGBXML(type, config);
-                case Schema.EnergyPlusLoads:
-                    return ReadEnergyPlus(type, config);
-                case Schema.KML:
-                    BH.Engine.Reflection.Compute.RecordError("The KML Schema is not supported for pull operations at this time");
-                    return new List<IBHoMObject>();
-                default:
-                    BH.Engine.Reflection.Compute.RecordError("The XML Schema you have supplied is not currently supported by the XML Toolkit");
-                    return new List<IBHoMObject>();
-            }
+            return new List<IBHoMObject> { report };
         }
     }
 }

--- a/XML_Adapter/CRUD/GBXML/CreateGBXML.cs
+++ b/XML_Adapter/CRUD/GBXML/CreateGBXML.cs
@@ -29,7 +29,6 @@ using System.Xml.Serialization;
 using System.IO;
 
 using BH.oM.Adapters.XML;
-using BH.oM.Adapters.XML;
 using BH.oM.Adapters.XML.Settings;
 using BH.oM.Environment.Elements;
 using BH.oM.Base;

--- a/XML_Adapter/XML_Adapter.csproj
+++ b/XML_Adapter/XML_Adapter.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Convert\KML\ToKML.cs" />
     <Compile Include="Convert\KML\ToLatLon.cs" />
     <Compile Include="CRUD\Create.cs" />
+    <Compile Include="CRUD\EnergyPlus\ReadEnergyPlus.cs" />
     <Compile Include="CRUD\GBXML\CreateGBXML.cs" />
     <Compile Include="CRUD\GBXML\ReadGBXML.cs" />
     <Compile Include="CRUD\KML\CreateKML.cs" />

--- a/XML_oM/EnergyPlus/CoolingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/CoolingPeakCondition.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.Xml.Serialization;
+using BH.oM.Base;
+
+namespace BH.oM.XML.EnergyPlus
+{
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class CoolingPeakCondition : BHoMObject
+    {
+        [XmlAttribute("name")]
+        public override string Name { get; set; } = "";
+
+        [XmlAttribute("TimeOfPeakLoad")]
+        public string TimeOfPeakLoad { get; set; } = "";
+
+        [XmlAttribute("OutsideDryBulbTemperature")]
+        public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
+
+        [XmlAttribute("OutsideWetBulbTemperature")]
+        public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
+
+        [XmlAttribute("OutsideHumidityRatioAtPeak")]
+        public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
+
+        [XmlAttribute("ZoneDryBulbTemperature")]
+        public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
+
+        [XmlAttribute("ZoneRelativeHumdity")]
+        public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
+
+        [XmlAttribute("ZoneHumidityRatioAtPeak")]
+        public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
+
+        [XmlAttribute("PeakDesignSensibleLoad")]
+        public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
+
+        [XmlAttribute("EstimatedInstantDelayedSensibleLoad")]
+        public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
+
+        [XmlAttribute("Difference")]
+        public Difference Difference { get; set; } = new Difference();
+    }
+}

--- a/XML_oM/EnergyPlus/CoolingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/CoolingPeakCondition.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -39,33 +39,33 @@ namespace BH.oM.XML.EnergyPlus
         public override string Name { get; set; } = "";
 
         [XmlAttribute("TimeOfPeakLoad")]
-        public string TimeOfPeakLoad { get; set; } = "";
+        public virtual string TimeOfPeakLoad { get; set; } = "";
 
         [XmlElement("OutsideDryBulbTemperature")]
-        public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
+        public virtual OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
 
         [XmlElement("OutsideWetBulbTemperature")]
-        public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
+        public virtual OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
 
         [XmlElement("OutsideHumidityRatioAtPeak")]
-        public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
+        public virtual OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
 
         [XmlElement("ZoneDryBulbTemperature")]
-        public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
+        public virtual ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
 
         [XmlElement("ZoneRelativeHumdity")]
-        public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
+        public virtual ZoneRelativeHumidity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumidity();
 
         [XmlElement("ZoneHumidityRatioAtPeak")]
-        public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
+        public virtual ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
 
         [XmlElement("PeakDesignSensibleLoad")]
-        public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
+        public virtual PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
 
         [XmlElement("EstimatedInstantDelayedSensibleLoad")]
-        public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
+        public virtual EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
 
         [XmlElement("Difference")]
-        public Difference Difference { get; set; } = new Difference();
+        public virtual Difference Difference { get; set; } = new Difference();
     }
 }

--- a/XML_oM/EnergyPlus/CoolingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/CoolingPeakCondition.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class CoolingPeakCondition : BHoMObject
+    public class CoolingPeakCondition : EnergyPlusObject
     {
         [XmlAttribute("name")]
         public override string Name { get; set; } = "";

--- a/XML_oM/EnergyPlus/CoolingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/CoolingPeakCondition.cs
@@ -41,31 +41,31 @@ namespace BH.oM.XML.EnergyPlus
         [XmlAttribute("TimeOfPeakLoad")]
         public string TimeOfPeakLoad { get; set; } = "";
 
-        [XmlAttribute("OutsideDryBulbTemperature")]
+        [XmlElement("OutsideDryBulbTemperature")]
         public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
 
-        [XmlAttribute("OutsideWetBulbTemperature")]
+        [XmlElement("OutsideWetBulbTemperature")]
         public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
 
-        [XmlAttribute("OutsideHumidityRatioAtPeak")]
+        [XmlElement("OutsideHumidityRatioAtPeak")]
         public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
 
-        [XmlAttribute("ZoneDryBulbTemperature")]
+        [XmlElement("ZoneDryBulbTemperature")]
         public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
 
-        [XmlAttribute("ZoneRelativeHumdity")]
+        [XmlElement("ZoneRelativeHumdity")]
         public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
 
-        [XmlAttribute("ZoneHumidityRatioAtPeak")]
+        [XmlElement("ZoneHumidityRatioAtPeak")]
         public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
 
-        [XmlAttribute("PeakDesignSensibleLoad")]
+        [XmlElement("PeakDesignSensibleLoad")]
         public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
 
-        [XmlAttribute("EstimatedInstantDelayedSensibleLoad")]
+        [XmlElement("EstimatedInstantDelayedSensibleLoad")]
         public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
 
-        [XmlAttribute("Difference")]
+        [XmlElement("Difference")]
         public Difference Difference { get; set; } = new Difference();
     }
 }

--- a/XML_oM/EnergyPlus/Difference.cs
+++ b/XML_oM/EnergyPlus/Difference.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class Difference : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/Difference.cs
+++ b/XML_oM/EnergyPlus/Difference.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class Difference : BHoMObject
+    public class Difference : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/Difference.cs
+++ b/XML_oM/EnergyPlus/Difference.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class Difference : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/EnergyPlusObject.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusObject.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/EnergyPlus/EnergyPlusObject.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusObject.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,18 +28,25 @@ using System.Text;
 using System.Threading.Tasks;
 
 using System.Xml.Serialization;
-using BH.oM.Base;
 
 namespace BH.oM.XML.EnergyPlus
 {
-    [Serializable]
-    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class ZoneDryBulbTemperature : EnergyPlusObject
+    public class EnergyPlusObject : IBHoMObject
     {
-        [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        [XmlIgnore]
+        public virtual Guid BHoM_Guid { get; set; }
+        [XmlIgnore]
+        public virtual Dictionary<string, object> CustomData { get; set; }
+        [XmlIgnore]
+        public virtual string Name { get; set; }
+        [XmlIgnore]
+        public virtual FragmentSet Fragments { get; set; }
+        [XmlIgnore]
+        public virtual HashSet<string> Tags { get; set; }
 
-        [XmlText]
-        public string Value { get; set; } = "";
+        public IBHoMObject GetShallowClone(bool newGuid = false)
+        {
+            return this;
+        }
     }
 }

--- a/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
@@ -26,19 +26,31 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class EnergyPlusTabularReport : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlElement("BuildingName")]
+        public string BuildingName { get; set; } = "";
+
+        [XmlElement("EnvironmentName")]
+        public string EnvironmentName { get; set; } = "";
+
+        [XmlElement("WeatherFileLocationTitle")]
+        public string WeatherFileLocationTitle { get; set; } = "";
+
+        [XmlElement("ProgramVersion")]
+        public string ProgramVersion { get; set; } = "";
+
+        [XmlElement("SimulationTimestamp")]
+        public SimulationTimestamp SimulationTimestamp { get; set; } = new SimulationTimestamp();
+
+        [XmlElement("ZoneComponentLoadSumary")]
+        public ZoneComponentLoadSummary[] ZoneComponentLoadSummaries { get; set; } = new List<ZoneComponentLoadSummary>().ToArray();
     }
 }

--- a/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,21 +36,21 @@ namespace BH.oM.XML.EnergyPlus
     public class EnergyPlusTabularReport : EnergyPlusObject
     {
         [XmlElement("BuildingName")]
-        public string BuildingName { get; set; } = "";
+        public virtual string BuildingName { get; set; } = "";
 
         [XmlElement("EnvironmentName")]
-        public string EnvironmentName { get; set; } = "";
+        public virtual string EnvironmentName { get; set; } = "";
 
         [XmlElement("WeatherFileLocationTitle")]
-        public string WeatherFileLocationTitle { get; set; } = "";
+        public virtual string WeatherFileLocationTitle { get; set; } = "";
 
         [XmlElement("ProgramVersion")]
-        public string ProgramVersion { get; set; } = "";
+        public virtual string ProgramVersion { get; set; } = "";
 
         [XmlElement("SimulationTimestamp")]
-        public SimulationTimestamp SimulationTimestamp { get; set; } = new SimulationTimestamp();
+        public virtual SimulationTimestamp SimulationTimestamp { get; set; } = new SimulationTimestamp();
 
         [XmlElement("ZoneComponentLoadSummary")]
-        public ZoneComponentLoadSummary[] ZoneComponentLoadSummary { get; set; } = new List<ZoneComponentLoadSummary>().ToArray();
+        public virtual ZoneComponentLoadSummary[] ZoneComponentLoadSummary { get; set; } = new List<ZoneComponentLoadSummary>().ToArray();
     }
 }

--- a/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
@@ -50,7 +50,7 @@ namespace BH.oM.XML.EnergyPlus
         [XmlElement("SimulationTimestamp")]
         public SimulationTimestamp SimulationTimestamp { get; set; } = new SimulationTimestamp();
 
-        [XmlElement("ZoneComponentLoadSumary")]
-        public ZoneComponentLoadSummary[] ZoneComponentLoadSummaries { get; set; } = new List<ZoneComponentLoadSummary>().ToArray();
+        [XmlElement("ZoneComponentLoadSummary")]
+        public ZoneComponentLoadSummary[] ZoneComponentLoadSummary { get; set; } = new List<ZoneComponentLoadSummary>().ToArray();
     }
 }

--- a/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
+++ b/XML_oM/EnergyPlus/EnergyPlusTabularReport.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class EnergyPlusTabularReport : BHoMObject
+    public class EnergyPlusTabularReport : EnergyPlusObject
     {
         [XmlElement("BuildingName")]
         public string BuildingName { get; set; } = "";

--- a/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
+++ b/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
@@ -26,19 +26,34 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class EstimatedCoolingPeakLoadComponent : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlElement("name")]
+        public override string Name { get; set; } = "";
+
+        [XmlElement("SensibleInstant")]
+        public SensibleInstant SensibleInstant { get; set; } = new SensibleInstant();
+
+        [XmlElement("SensibleDelayed")]
+        public SensibleDelayed SensibleDelayed { get; set; } = new SensibleDelayed();
+
+        [XmlElement("SensibleReturnAir")]
+        public SensibleReturnAir SensibleReturnAir { get; set; } = new SensibleReturnAir();
+
+        [XmlElement("Latent")]
+        public Latent Latent { get; set; } = new Latent();
+
+        [XmlElement("Total")]
+        public Total Total { get; set; } = new Total();
+
+        [XmlAttribute("GrandTotal")]
+        public double GrandTotal { get; set; } = 0.0;
     }
 }

--- a/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
+++ b/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class EstimatedCoolingPeakLoadComponent : BHoMObject
+    public class EstimatedCoolingPeakLoadComponent : EnergyPlusObject
     {
         [XmlElement("name")]
         public override string Name { get; set; } = "";

--- a/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
+++ b/XML_oM/EnergyPlus/EstimatedCoolingPeakLoadComponent.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -39,21 +39,21 @@ namespace BH.oM.XML.EnergyPlus
         public override string Name { get; set; } = "";
 
         [XmlElement("SensibleInstant")]
-        public SensibleInstant SensibleInstant { get; set; } = new SensibleInstant();
+        public virtual SensibleInstant SensibleInstant { get; set; } = new SensibleInstant();
 
         [XmlElement("SensibleDelayed")]
-        public SensibleDelayed SensibleDelayed { get; set; } = new SensibleDelayed();
+        public virtual SensibleDelayed SensibleDelayed { get; set; } = new SensibleDelayed();
 
         [XmlElement("SensibleReturnAir")]
-        public SensibleReturnAir SensibleReturnAir { get; set; } = new SensibleReturnAir();
+        public virtual SensibleReturnAir SensibleReturnAir { get; set; } = new SensibleReturnAir();
 
         [XmlElement("Latent")]
-        public Latent Latent { get; set; } = new Latent();
+        public virtual Latent Latent { get; set; } = new Latent();
 
         [XmlElement("Total")]
-        public Total Total { get; set; } = new Total();
+        public virtual Total Total { get; set; } = new Total();
 
-        [XmlAttribute("GrandTotal")]
-        public double GrandTotal { get; set; } = 0.0;
+        [XmlElement("GrandTotal")]
+        public virtual double GrandTotal { get; set; } = 0.0;
     }
 }

--- a/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class EstimatedInstantDelayedSensibleLoad : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class EstimatedInstantDelayedSensibleLoad : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/EstimatedInstantDelayedSensibleLoad.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class EstimatedInstantDelayedSensibleLoad : BHoMObject
+    public class EstimatedInstantDelayedSensibleLoad : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/HeatingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/HeatingPeakCondition.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -39,33 +39,33 @@ namespace BH.oM.XML.EnergyPlus
         public override string Name { get; set; } = "";
 
         [XmlAttribute("TimeOfPeakLoad")]
-        public string TimeOfPeakLoad { get; set; } = "";
+        public virtual string TimeOfPeakLoad { get; set; } = "";
 
         [XmlElement("OutsideDryBulbTemperature")]
-        public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
+        public virtual OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
 
         [XmlElement("OutsideWetBulbTemperature")]
-        public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
+        public virtual OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
 
         [XmlElement("OutsideHumidityRatioAtPeak")]
-        public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
+        public virtual OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
 
         [XmlElement("ZoneDryBulbTemperature")]
-        public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
+        public virtual ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
 
         [XmlElement("ZoneRelativeHumdity")]
-        public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
+        public virtual ZoneRelativeHumidity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumidity();
 
         [XmlElement("ZoneHumidityRatioAtPeak")]
-        public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
+        public virtual ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
 
         [XmlElement("PeakDesignSensibleLoad")]
-        public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
+        public virtual PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
 
         [XmlElement("EstimatedInstantDelayedSensibleLoad")]
-        public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
+        public virtual EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
 
         [XmlElement("Difference")]
-        public Difference Difference { get; set; } = new Difference();
+        public virtual Difference Difference { get; set; } = new Difference();
     }
 }

--- a/XML_oM/EnergyPlus/HeatingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/HeatingPeakCondition.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.Xml.Serialization;
+using BH.oM.Base;
+
+namespace BH.oM.XML.EnergyPlus
+{
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class HeatingPeakCondition : BHoMObject
+    {
+        [XmlAttribute("name")]
+        public override string Name { get; set; } = "";
+
+        [XmlAttribute("TimeOfPeakLoad")]
+        public string TimeOfPeakLoad { get; set; } = "";
+
+        [XmlAttribute("OutsideDryBulbTemperature")]
+        public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
+
+        [XmlAttribute("OutsideWetBulbTemperature")]
+        public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
+
+        [XmlAttribute("OutsideHumidityRatioAtPeak")]
+        public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
+
+        [XmlAttribute("ZoneDryBulbTemperature")]
+        public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
+
+        [XmlAttribute("ZoneRelativeHumdity")]
+        public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
+
+        [XmlAttribute("ZoneHumidityRatioAtPeak")]
+        public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
+
+        [XmlAttribute("PeakDesignSensibleLoad")]
+        public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
+
+        [XmlAttribute("EstimatedInstantDelayedSensibleLoad")]
+        public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
+
+        [XmlAttribute("Difference")]
+        public Difference Difference { get; set; } = new Difference();
+    }
+}

--- a/XML_oM/EnergyPlus/HeatingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/HeatingPeakCondition.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class HeatingPeakCondition : BHoMObject
+    public class HeatingPeakCondition : EnergyPlusObject
     {
         [XmlAttribute("name")]
         public override string Name { get; set; } = "";

--- a/XML_oM/EnergyPlus/HeatingPeakCondition.cs
+++ b/XML_oM/EnergyPlus/HeatingPeakCondition.cs
@@ -41,31 +41,31 @@ namespace BH.oM.XML.EnergyPlus
         [XmlAttribute("TimeOfPeakLoad")]
         public string TimeOfPeakLoad { get; set; } = "";
 
-        [XmlAttribute("OutsideDryBulbTemperature")]
+        [XmlElement("OutsideDryBulbTemperature")]
         public OutsideDryBulbTemperature OutsideDryBulbTemperature { get; set; } = new OutsideDryBulbTemperature();
 
-        [XmlAttribute("OutsideWetBulbTemperature")]
+        [XmlElement("OutsideWetBulbTemperature")]
         public OutsideWetBulbTemperature OutsideWetBulbTemperature { get; set; } = new OutsideWetBulbTemperature();
 
-        [XmlAttribute("OutsideHumidityRatioAtPeak")]
+        [XmlElement("OutsideHumidityRatioAtPeak")]
         public OutsideHumidityRatioAtPeak OutsideHumidityRatioAtPeak { get; set; } = new OutsideHumidityRatioAtPeak();
 
-        [XmlAttribute("ZoneDryBulbTemperature")]
+        [XmlElement("ZoneDryBulbTemperature")]
         public ZoneDryBulbTemperature ZoneDryBulbTemperature { get; set; } = new ZoneDryBulbTemperature();
 
-        [XmlAttribute("ZoneRelativeHumdity")]
+        [XmlElement("ZoneRelativeHumdity")]
         public ZoneRelativeHumdity ZoneRelativeHumdity { get; set; } = new ZoneRelativeHumdity();
 
-        [XmlAttribute("ZoneHumidityRatioAtPeak")]
+        [XmlElement("ZoneHumidityRatioAtPeak")]
         public ZoneHumidityRatioAtPeak ZoneHumidityRatioAtPeak { get; set; } = new ZoneHumidityRatioAtPeak();
 
-        [XmlAttribute("PeakDesignSensibleLoad")]
+        [XmlElement("PeakDesignSensibleLoad")]
         public PeakDesignSensibleLoad PeakDesignSensibleLoad { get; set; } = new PeakDesignSensibleLoad();
 
-        [XmlAttribute("EstimatedInstantDelayedSensibleLoad")]
+        [XmlElement("EstimatedInstantDelayedSensibleLoad")]
         public EstimatedInstantDelayedSensibleLoad EstimatedInstantDelayedSensibleLoad { get; set; } = new EstimatedInstantDelayedSensibleLoad();
 
-        [XmlAttribute("Difference")]
+        [XmlElement("Difference")]
         public Difference Difference { get; set; } = new Difference();
     }
 }

--- a/XML_oM/EnergyPlus/Latent.cs
+++ b/XML_oM/EnergyPlus/Latent.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class Latent : BHoMObject
+    public class Latent : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/Latent.cs
+++ b/XML_oM/EnergyPlus/Latent.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class Latent : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/Latent.cs
+++ b/XML_oM/EnergyPlus/Latent.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class Latent : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class OutsideDryBulbTemperature : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class OutsideDryBulbTemperature : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideDryBulbTemperature.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class OutsideDryBulbTemperature : BHoMObject
+    public class OutsideDryBulbTemperature : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class OutsideHumidityRatioAtPeak : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class OutsideHumidityRatioAtPeak : BHoMObject
+    public class OutsideHumidityRatioAtPeak : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/OutsideHumidityRatioAtPeak.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class OutsideHumidityRatioAtPeak : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideWebBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideWebBulbTemperature.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class OutsideWetBulbTemperature : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/OutsideWebBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideWebBulbTemperature.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class OutsideWetBulbTemperature : BHoMObject
+    public class OutsideWetBulbTemperature : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/OutsideWetBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/OutsideWetBulbTemperature.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class OutsideWetBulbTemperature : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class PeakDesignSensibleLoad : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class PeakDesignSensibleLoad : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
+++ b/XML_oM/EnergyPlus/PeakDesignSensibleLoad.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class PeakDesignSensibleLoad : BHoMObject
+    public class PeakDesignSensibleLoad : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/SensibleDelayed.cs
+++ b/XML_oM/EnergyPlus/SensibleDelayed.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class SensibleDelayed : BHoMObject
+    public class SensibleDelayed : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/SensibleDelayed.cs
+++ b/XML_oM/EnergyPlus/SensibleDelayed.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class SensibleDelayed : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SensibleDelayed.cs
+++ b/XML_oM/EnergyPlus/SensibleDelayed.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class SensibleDelayed : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SensibleInstant.cs
+++ b/XML_oM/EnergyPlus/SensibleInstant.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class SensibleInstant : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SensibleInstant.cs
+++ b/XML_oM/EnergyPlus/SensibleInstant.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class SensibleInstant : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SensibleInstant.cs
+++ b/XML_oM/EnergyPlus/SensibleInstant.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class SensibleInstant : BHoMObject
+    public class SensibleInstant : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/SensibleReturnAir.cs
+++ b/XML_oM/EnergyPlus/SensibleReturnAir.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class SensibleReturnAir : BHoMObject
+    public class SensibleReturnAir : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/SensibleReturnAir.cs
+++ b/XML_oM/EnergyPlus/SensibleReturnAir.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class SensibleReturnAir : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SensibleReturnAir.cs
+++ b/XML_oM/EnergyPlus/SensibleReturnAir.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class SensibleReturnAir : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SimulationTimestamp.cs
+++ b/XML_oM/EnergyPlus/SimulationTimestamp.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class SimulationTimestamp : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlElement("Date")]
+        public string Date { get; set; } = "";
+
+        [XmlElement("Time")]
+        public string Time { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SimulationTimestamp.cs
+++ b/XML_oM/EnergyPlus/SimulationTimestamp.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class SimulationTimestamp : EnergyPlusObject
     {
         [XmlElement("Date")]
-        public string Date { get; set; } = "";
+        public virtual string Date { get; set; } = "";
 
         [XmlElement("Time")]
-        public string Time { get; set; } = "";
+        public virtual string Time { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/SimulationTimestamp.cs
+++ b/XML_oM/EnergyPlus/SimulationTimestamp.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class SimulationTimestamp : BHoMObject
+    public class SimulationTimestamp : EnergyPlusObject
     {
         [XmlElement("Date")]
         public string Date { get; set; } = "";

--- a/XML_oM/EnergyPlus/Total.cs
+++ b/XML_oM/EnergyPlus/Total.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class Total : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/Total.cs
+++ b/XML_oM/EnergyPlus/Total.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class Total : BHoMObject
+    public class Total : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/Total.cs
+++ b/XML_oM/EnergyPlus/Total.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class Total : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
+++ b/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class ZoneComponentLoadSummary : BHoMObject
+    public class ZoneComponentLoadSummary : EnergyPlusObject
     {
         [XmlElement("for")]
         public string For { get; set; } = "";

--- a/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
+++ b/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,15 +36,15 @@ namespace BH.oM.XML.EnergyPlus
     public class ZoneComponentLoadSummary : EnergyPlusObject
     {
         [XmlElement("for")]
-        public string For { get; set; } = "";
+        public virtual string For { get; set; } = "";
 
         [XmlElement("EstimatedCoolingPeakLoadComponents")]
-        public EstimatedCoolingPeakLoadComponent[] EstimatedCoolingPeakLoadComponent { get; set; } = new List<EstimatedCoolingPeakLoadComponent>().ToArray();
+        public virtual EstimatedCoolingPeakLoadComponent[] EstimatedCoolingPeakLoadComponent { get; set; } = new List<EstimatedCoolingPeakLoadComponent>().ToArray();
 
         [XmlElement("CoolingPeakConditions")]
-        public CoolingPeakCondition CoolingPeakConditions { get; set; } = new CoolingPeakCondition();
+        public virtual CoolingPeakCondition CoolingPeakConditions { get; set; } = new CoolingPeakCondition();
 
         [XmlElement("HeatingPeakConditions")]
-        public HeatingPeakCondition HeatingPeakConditions { get; set; } = new HeatingPeakCondition();
+        public virtual HeatingPeakCondition HeatingPeakConditions { get; set; } = new HeatingPeakCondition();
     }
 }

--- a/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
+++ b/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
@@ -26,19 +26,25 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class ZoneComponentLoadSummary : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlElement("for")]
+        public string For { get; set; } = "";
+
+        [XmlAttribute("EstimatedCoolingPeakLoadComponents")]
+        public EstimatedCoolingPeakLoadComponent[] EstimatedCoolingPeakLoadComponent { get; set; } = new List<EstimatedCoolingPeakLoadComponent>().ToArray();
+
+        [XmlAttribute("CoolingPeakConditions")]
+        public CoolingPeakCondition CoolingPeakConditions { get; set; } = new CoolingPeakCondition();
+
+        [XmlAttribute("HeatingPeakConditions")]
+        public HeatingPeakCondition HeatingPeakConditions { get; set; } = new HeatingPeakCondition();
     }
 }

--- a/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
+++ b/XML_oM/EnergyPlus/ZoneComponentLoadSummary.cs
@@ -38,13 +38,13 @@ namespace BH.oM.XML.EnergyPlus
         [XmlElement("for")]
         public string For { get; set; } = "";
 
-        [XmlAttribute("EstimatedCoolingPeakLoadComponents")]
+        [XmlElement("EstimatedCoolingPeakLoadComponents")]
         public EstimatedCoolingPeakLoadComponent[] EstimatedCoolingPeakLoadComponent { get; set; } = new List<EstimatedCoolingPeakLoadComponent>().ToArray();
 
-        [XmlAttribute("CoolingPeakConditions")]
+        [XmlElement("CoolingPeakConditions")]
         public CoolingPeakCondition CoolingPeakConditions { get; set; } = new CoolingPeakCondition();
 
-        [XmlAttribute("HeatingPeakConditions")]
+        [XmlElement("HeatingPeakConditions")]
         public HeatingPeakCondition HeatingPeakConditions { get; set; } = new HeatingPeakCondition();
     }
 }

--- a/XML_oM/EnergyPlus/ZoneDryBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/ZoneDryBulbTemperature.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class ZoneDryBulbTemperature : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneDryBulbTemperature.cs
+++ b/XML_oM/EnergyPlus/ZoneDryBulbTemperature.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class ZoneDryBulbTemperature : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class ZoneHumidityRatioAtPeak : BHoMObject
+    public class ZoneHumidityRatioAtPeak : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -36,9 +36,9 @@ namespace BH.oM.XML.EnergyPlus
     public class ZoneHumidityRatioAtPeak : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
+++ b/XML_oM/EnergyPlus/ZoneHumidityRatioAtPeak.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class ZoneHumidityRatioAtPeak : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneRelativeHumidity.cs
+++ b/XML_oM/EnergyPlus/ZoneRelativeHumidity.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -33,12 +33,12 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class ZoneRelativeHumdity : EnergyPlusObject
+    public class ZoneRelativeHumidity : EnergyPlusObject
     {
         [XmlAttribute("units")]
-        public string Unit { get; set; } = "";
+        public virtual string Unit { get; set; } = "";
 
         [XmlText]
-        public string Value { get; set; } = "";
+        public virtual string Value { get; set; } = "";
     }
 }

--- a/XML_oM/EnergyPlus/ZoneRelativeHumidty.cs
+++ b/XML_oM/EnergyPlus/ZoneRelativeHumidty.cs
@@ -33,7 +33,7 @@ namespace BH.oM.XML.EnergyPlus
 {
     [Serializable]
     [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
-    public class ZoneRelativeHumdity : BHoMObject
+    public class ZoneRelativeHumdity : EnergyPlusObject
     {
         [XmlAttribute("units")]
         public string Unit { get; set; } = "";

--- a/XML_oM/EnergyPlus/ZoneRelativeHumidty.cs
+++ b/XML_oM/EnergyPlus/ZoneRelativeHumidty.cs
@@ -26,19 +26,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using System.ComponentModel;
+using System.Xml.Serialization;
+using BH.oM.Base;
 
-namespace BH.oM.Adapters.XML.Enums
+namespace BH.oM.XML.EnergyPlus
 {
-    [Description("Defines the XML Schema that is being used within the context of the XML Toolkit")]
-    public enum Schema
+    [Serializable]
+    [XmlRoot(ElementName = "EnergyPlusTabularReports", IsNullable = false, Namespace = "")]
+    public class ZoneRelativeHumdity : BHoMObject
     {
-        Undefined,
-        [Description("EnergyPlusLoads is the XML schema for load results calculated using the EnergyPlus software")]
-        EnergyPlusLoads,
-        [Description("gbXML Schema is the Green Building XML Schema, used by environment modelling software for the transfer of building geometry and data to tools such as IES, TAS, and more")]
-        GBXML,
-        [Description("KML is a file format used to display geographic data in an Earth browser such as Google Earth")]
-        KML,
+        [XmlAttribute("units")]
+        public string Unit { get; set; } = "";
+
+        [XmlText]
+        public string Value { get; set; } = "";
     }
 }

--- a/XML_oM/Enums/AltitudeMode.cs
+++ b/XML_oM/Enums/AltitudeMode.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -24,8 +24,9 @@ namespace BH.oM.Adapters.XML.Enums
 {
     public enum AltitudeMode
     {
+        Undefined,
+        Absolute,
         ClampToGround,
         RelativeToGround,
-        Absolute
     }
 }

--- a/XML_oM/Enums/Schema.cs
+++ b/XML_oM/Enums/Schema.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/KML/GeoReference.cs
+++ b/XML_oM/KML/GeoReference.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/KML/KMLDocumentBuilder.cs
+++ b/XML_oM/KML/KMLDocumentBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/KML/KMLGeometry.cs
+++ b/XML_oM/KML/KMLGeometry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/Settings/IXMLSettings.cs
+++ b/XML_oM/Settings/IXMLSettings.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/Settings/KMLSettings.cs
+++ b/XML_oM/Settings/KMLSettings.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/XMLConfig.cs
+++ b/XML_oM/XMLConfig.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -71,7 +71,7 @@
     <Compile Include="EnergyPlus\Latent.cs" />
     <Compile Include="EnergyPlus\OutsideDryBulbTemperature.cs" />
     <Compile Include="EnergyPlus\OutsideHumidityRatioAtPeak.cs" />
-    <Compile Include="EnergyPlus\OutsideWebBulbTemperature.cs" />
+    <Compile Include="EnergyPlus\OutsideWetBulbTemperature.cs" />
     <Compile Include="EnergyPlus\PeakDesignSensibleLoad.cs" />
     <Compile Include="EnergyPlus\SensibleDelayed.cs" />
     <Compile Include="EnergyPlus\SensibleInstant.cs" />
@@ -81,7 +81,7 @@
     <Compile Include="EnergyPlus\ZoneComponentLoadSummary.cs" />
     <Compile Include="EnergyPlus\ZoneDryBulbTemperature.cs" />
     <Compile Include="EnergyPlus\ZoneHumidityRatioAtPeak.cs" />
-    <Compile Include="EnergyPlus\ZoneRelativeHumidty.cs" />
+    <Compile Include="EnergyPlus\ZoneRelativeHumidity.cs" />
     <Compile Include="Enums\AltitudeMode.cs" />
     <Compile Include="GBXML\GBXMLDocumentBuilder.cs" />
     <Compile Include="Enums\ExportDetail.cs" />

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="EnergyPlus\CoolingPeakCondition.cs" />
     <Compile Include="EnergyPlus\Difference.cs" />
+    <Compile Include="EnergyPlus\EnergyPlusObject.cs" />
     <Compile Include="EnergyPlus\EnergyPlusTabularReport.cs" />
     <Compile Include="EnergyPlus\EstimatedCoolingPeakLoadComponent.cs" />
     <Compile Include="EnergyPlus\EstimatedInstantDelayedSensibleLoad.cs" />

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -31,24 +31,24 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Adapter_oM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Architecture_oM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Architecture_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Architecture_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Environment_oM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -61,6 +61,26 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnergyPlus\CoolingPeakCondition.cs" />
+    <Compile Include="EnergyPlus\Difference.cs" />
+    <Compile Include="EnergyPlus\EnergyPlusTabularReport.cs" />
+    <Compile Include="EnergyPlus\EstimatedCoolingPeakLoadComponent.cs" />
+    <Compile Include="EnergyPlus\EstimatedInstantDelayedSensibleLoad.cs" />
+    <Compile Include="EnergyPlus\HeatingPeakCondition.cs" />
+    <Compile Include="EnergyPlus\Latent.cs" />
+    <Compile Include="EnergyPlus\OutsideDryBulbTemperature.cs" />
+    <Compile Include="EnergyPlus\OutsideHumidityRatioAtPeak.cs" />
+    <Compile Include="EnergyPlus\OutsideWebBulbTemperature.cs" />
+    <Compile Include="EnergyPlus\PeakDesignSensibleLoad.cs" />
+    <Compile Include="EnergyPlus\SensibleDelayed.cs" />
+    <Compile Include="EnergyPlus\SensibleInstant.cs" />
+    <Compile Include="EnergyPlus\SensibleReturnAir.cs" />
+    <Compile Include="EnergyPlus\SimulationTimestamp.cs" />
+    <Compile Include="EnergyPlus\Total.cs" />
+    <Compile Include="EnergyPlus\ZoneComponentLoadSummary.cs" />
+    <Compile Include="EnergyPlus\ZoneDryBulbTemperature.cs" />
+    <Compile Include="EnergyPlus\ZoneHumidityRatioAtPeak.cs" />
+    <Compile Include="EnergyPlus\ZoneRelativeHumidty.cs" />
     <Compile Include="Enums\AltitudeMode.cs" />
     <Compile Include="GBXML\GBXMLDocumentBuilder.cs" />
     <Compile Include="Enums\ExportDetail.cs" />


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #477 


 ### Test files
See issue for example XML file.
[Script.zip](https://github.com/BHoM/XML_Toolkit/files/4904347/Script.zip)
Example script to do the pull and exploding 



 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
This now adds the ability to pull a third schema of XML - EnergyPlus Loads results.

Currently does not deserialise into valid BHoM objects, and this will need the be fixed before the beta (so please don't build too many workflows on this as the objects will change) but a proof of concept on the new schema!