### PR TITLE
Remove reference to AdapterIdName in the constructor

### DIFF
--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -61,7 +61,6 @@ namespace BH.Adapter.XML
 
             _fileSettings = fileSettings;
 
-            AdapterIdName = "XML_Adapter";
         }
 
         private BH.oM.Adapter.FileSettings _fileSettings { get; set; } = null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #500 (half millennium celebration! Not the most exciting issue though!)

<!-- Add short description of what has been fixed -->

Removing reference to AdapterNameId being removed in https://github.com/BHoM/BHoM_Adapter/pull/263

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->