### PR TITLE
Removing reference to the deprecated Centre() method

### DIFF
--- a/XML_Adapter/Convert/GBXML/Environment/Opening.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Opening.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter.XML
             gbOpening.ID = "opening" + opening.BHoM_Guid.ToString().Replace("-", "").Substring(0, 5);
             gbOpening.PlanarGeometry.PolyLoop = pLine.ToGBXML(settings);
             gbOpening.PlanarGeometry.ID = "openingPGeom-" + Guid.NewGuid().ToString().Replace("-", "").Substring(0, 5);
-            gbOpening.RectangularGeometry.CartesianPoint = BH.Engine.Geometry.Query.Centre(pLine).ToGBXML(settings);
+            gbOpening.RectangularGeometry.CartesianPoint = BH.Engine.Geometry.Query.Centroid(pLine).ToGBXML(settings);
             gbOpening.RectangularGeometry.Height = Math.Round(opening.Height(), settings.RoundingSettings.GeometryHeight);
             //TODO: temporary solution to get valid file to be replaced with correct height
             if (opening.Height() == 0)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
[#2263](https://github.com/BHoM/BHoM_Engine/pull/2263) Main pull request in the Geometry_Engine.

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Replacing reference to `Centre()` with `Centroid()`.

### Changelog
- Updating `Opening` method to call for `Centroid` instead of `Centre`.
