### PR TITLE
XML with default schema now reading as custom objects

### DIFF
--- a/XML_Adapter/CRUD/Default/ReadDefault.cs
+++ b/XML_Adapter/CRUD/Default/ReadDefault.cs
@@ -51,8 +51,14 @@ namespace BH.Adapter.XML
     {
         private IEnumerable<IBHoMObject> ReadDefault(Type type = null, XMLConfig config = null)
         {
+            //Most XML files include header information, which causes the XmlTextReader to fail. Removing the header information fixes this failure. 
+            //Assuming the header information isn't important to us, we can remove it. 
+            List<string> docLines = File.ReadAllLines(_fileSettings.GetFullFileName()).ToList();
+            if (docLines[0].StartsWith(@"<?xml"))
+                docLines.RemoveAt(0);
+
             //Due to needing to read an XML file without a schema, we read each node instead and convert it to a JSON string which we then deserialise via Serialiser_Engine to get the custom objects
-            XmlTextReader reader = new XmlTextReader(_fileSettings.GetFullFileName());
+            XmlTextReader reader = new XmlTextReader(new StringReader(string.Join(Environment.NewLine, docLines)));
             XmlDocument doc = new XmlDocument();
             XmlNode node = doc.ReadNode(reader);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Some XML files with an undefined schema were previously not being read into custom objects correctly. It appears that XML files with header information were causing the XmlReader to fail. This has been fixed by ignoring header information when parsing the XML file. 

Limits of this fix:
- If the first line of the XML file starts with `<?xml`, then this first line is ignored. If this bug exists under different conditions, this will need raising as a separate issue. 


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #537 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
Refer to test file provided on issue. 

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->