### PR TITLE
XML_Toolkit: Relinking FindFragment

### DIFF
--- a/XML_Adapter/Convert/GBXML/Environment/Building.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Building.cs
@@ -30,14 +30,13 @@ using BHE = BH.oM.Environment.Elements;
 using BHP = BH.oM.Environment.Fragments;
 using BHX = BH.Adapter.XML.GBXMLSchema;
 using BHG = BH.oM.Geometry;
-
 using BH.Engine.Geometry;
 using BH.Engine.Environment;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Adapters.XML.Settings;
 using BH.oM.XML.Fragments;
+using BH.Engine.Base;
 
 namespace BH.Adapter.XML
 {

--- a/XML_Adapter/Convert/GBXML/Environment/Construction.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Construction.cs
@@ -43,6 +43,7 @@ using BH.oM.Base.Attributes;
 
 using BH.Engine.Adapters.XML;
 using BH.oM.Adapters.XML.Settings;
+using BH.Engine.Base;
 
 namespace BH.Adapter.XML
 {

--- a/XML_Adapter/Convert/GBXML/Environment/Opening.cs
+++ b/XML_Adapter/Convert/GBXML/Environment/Opening.cs
@@ -40,6 +40,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 
 using BH.Engine.Adapters.XML;
+using BH.Engine.Base;
 
 namespace BH.Adapter.XML
 {

--- a/XML_Adapter/Convert/GBXML/ToGBXML.cs
+++ b/XML_Adapter/Convert/GBXML/ToGBXML.cs
@@ -36,6 +36,7 @@ using BH.oM.Physical.Constructions;
 
 using BH.Engine.Environment;
 using BH.oM.Adapters.XML;
+using BH.Engine.Base;
 
 namespace BH.Adapter.XML
 {

--- a/XML_Adapter/Query/CADObjectID.cs
+++ b/XML_Adapter/Query/CADObjectID.cs
@@ -27,13 +27,11 @@ using BH.Engine.Geometry;
 using System.Linq;
 using BHE = BH.oM.Environment.Elements;
 using BHP = BH.oM.Environment.Fragments;
-
 using BH.oM.Adapters.XML.Enums;
-
 using BH.Engine.Environment;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
+using BH.Engine.Base;
 
 namespace BH.Adapter.XML
 {


### PR DESCRIPTION
 ### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/2748


 ### Issues addressed by this PR
Fixing compilation failures that was caused by moving and removing FindFragment in Environment_Engine.

 Closes #2747

Have relinked FindFragment in relevant files.