### PR TITLE
Zero length string now handled for the Depth property

### DIFF
--- a/XML_Engine/Query/Depth.cs
+++ b/XML_Engine/Query/Depth.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Adapters.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns the 'depth' property of a markup object as a double. If the value cannot be converted to a double (if the value is null or blank for example) then an error will be returned.")]
+        [Description("Returns the 'depth' property of a markup object as a double. If the value cannot be converted to a double (if the value is null or blank for example) then an error will be provided and -1 will be returned.")]
         [Input("markup", "A markup object which contains the 'depth' property.")]
         [Output("depth", "The depth value as a double, or -1 if the value could not be converted to a double.")]
         public static double Depth(this Markup markup)

--- a/XML_Engine/Query/Depth.cs
+++ b/XML_Engine/Query/Depth.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Adapters.XML
 
         [Description("Returns the 'depth' property of a markup object as a double. If the value cannot be converted to a double (if the value is null or blank for example) then an error will be returned.")]
         [Input("markup", "A markup object which contains the 'depth' property.")]
-        [Output("Depth", "The depth value as a double, or -1 if the value could not be converted to a double.")]
+        [Output("depth", "The depth value as a double, or -1 if the value could not be converted to a double.")]
         public static double Depth(this Markup markup)
         {
             try

--- a/XML_Engine/Query/Depth.cs
+++ b/XML_Engine/Query/Depth.cs
@@ -43,10 +43,9 @@ namespace BH.Engine.Adapters.XML
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Determines whether a collection of Environment Panels representing a single space contains any panels which are externally facing")]
-        [Input("elementsAsSpace", "A collection of Environment Panels that represent closed spaced")]
-        [Input("elementsAsSpaces", "A nested collection of Environment Panels which represent all spaces in the model")]
-        [Output("isExternal", "True if the space has at least one externally facing Panel")]
+        [Description("Returns the 'depth' property of a markup object as a double. If the value cannot be converted to a double (if the value is null or blank for example) then an error will be returned.")]
+        [Input("markup", "A markup object which contains the 'depth' property.")]
+        [Output("Depth", "The depth value as a double, or -1 if the value could not be converted to a double.")]
         public static double Depth(this Markup markup)
         {
             try
@@ -55,7 +54,7 @@ namespace BH.Engine.Adapters.XML
             }
             catch (Exception e)
             {
-                BH.Engine.Base.Compute.RecordError("Could not convert XMLDepth to numerical depth.");
+                BH.Engine.Base.Compute.RecordError($"Could not convert XMLDepth value {markup.XMLDepth} to numerical depth.");
                 return -1;
             }
         }

--- a/XML_Engine/Query/Depth.cs
+++ b/XML_Engine/Query/Depth.cs
@@ -48,6 +48,9 @@ namespace BH.Engine.Adapters.XML
         [Output("depth", "The depth value as a double, or -1 if the value could not be converted to a double.")]
         public static double Depth(this Markup markup)
         {
+            if (markup == null)
+                return -1;
+
             try
             {
                 return System.Convert.ToDouble(markup.XMLDepth);

--- a/XML_Engine/Query/Depth.cs
+++ b/XML_Engine/Query/Depth.cs
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Environment.Elements;
+using BH.Engine.Environment;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.XML.Bluebeam;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Adapters.XML;
+using BH.oM.Adapters.XML.Enums;
+
+namespace BH.Engine.Adapters.XML
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Determines whether a collection of Environment Panels representing a single space contains any panels which are externally facing")]
+        [Input("elementsAsSpace", "A collection of Environment Panels that represent closed spaced")]
+        [Input("elementsAsSpaces", "A nested collection of Environment Panels which represent all spaces in the model")]
+        [Output("isExternal", "True if the space has at least one externally facing Panel")]
+        public static double Depth(this Markup markup)
+        {
+            try
+            {
+                return System.Convert.ToDouble(markup.XMLDepth);
+            }
+            catch (Exception e)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not convert XMLDepth to numerical depth.");
+                return -1;
+            }
+        }
+    }
+}
+

--- a/XML_Engine/XML_Engine.csproj
+++ b/XML_Engine/XML_Engine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -47,7 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM_Engine">
-      <HintPath>..\..\..\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>

--- a/XML_Engine/XML_Engine.csproj
+++ b/XML_Engine/XML_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -45,6 +45,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BHoM_Engine">
+      <HintPath>..\..\..\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
@@ -107,6 +110,7 @@
     <Compile Include="Query\CleanName.cs" />
     <Compile Include="Query\ExposedToSun.cs" />
     <Compile Include="Query\ExternalElements.cs" />
+    <Compile Include="Query\Depth.cs" />
     <Compile Include="Query\IsExternal.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/XML_oM/Bluebeam/Markup.cs
+++ b/XML_oM/Bluebeam/Markup.cs
@@ -65,8 +65,24 @@ namespace BH.oM.XML.Bluebeam
         public virtual string Label { get; set; }
 
         [XmlElement("Depth")]
-        public virtual double Depth { get; set; }
-
+        public string XMLDepth;
+        
+        public virtual double? Depth
+        {
+            get
+            {
+                try
+                {
+                    return Convert.ToDouble(XMLDepth);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            set { XMLDepth = value.ToString(); }
+        }
+        
         [XmlElement("Layer")]
         public virtual string Layer { get; set; }
     }

--- a/XML_oM/Bluebeam/Markup.cs
+++ b/XML_oM/Bluebeam/Markup.cs
@@ -80,7 +80,6 @@ namespace BH.oM.XML.Bluebeam
                     return null;
                 }
             }
-            set { XMLDepth = value.ToString(); }
         }
         
         [XmlElement("Layer")]

--- a/XML_oM/Bluebeam/Markup.cs
+++ b/XML_oM/Bluebeam/Markup.cs
@@ -65,22 +65,7 @@ namespace BH.oM.XML.Bluebeam
         public virtual string Label { get; set; }
 
         [XmlElement("Depth")]
-        public string XMLDepth;
-        
-        public virtual double? Depth
-        {
-            get
-            {
-                try
-                {
-                    return Convert.ToDouble(XMLDepth);
-                }
-                catch
-                {
-                    return null;
-                }
-            }
-        }
+        public string XMLDepth { get; set; }
         
         [XmlElement("Layer")]
         public virtual string Layer { get; set; }

--- a/XML_oM/Bluebeam/Markup.cs
+++ b/XML_oM/Bluebeam/Markup.cs
@@ -65,7 +65,7 @@ namespace BH.oM.XML.Bluebeam
         public virtual string Label { get; set; }
 
         [XmlElement("Depth")]
-        public string XMLDepth { get; set; }
+        public virtual string XMLDepth { get; set; }
         
         [XmlElement("Layer")]
         public virtual string Layer { get; set; }


### PR DESCRIPTION


 Closes #554 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed 
[test.zip](https://github.com/BHoM/XML_Toolkit/files/8762229/test.zip)
changes -->

Try different values of 'depth' in the XML file. Verify the value of 'Depth' in the exploded markup. 
[test.zip](https://github.com/BHoM/XML_Toolkit/files/8762243/test.zip)



 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->