### PR TITLE
Fix namespace of RoundingSettings to correctly include the "Adapters" word

### DIFF
--- a/XML_oM/GBXML/RoundingSettings.cs
+++ b/XML_oM/GBXML/RoundingSettings.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 
 using BH.oM.Base;
 
-namespace BH.oM.XML.GBXML
+namespace BH.oM.Adapters.XML.GBXML
 {
     public class RoundingSettings : BHoMObject
     {

--- a/XML_oM/Settings/GBXMLSettings.cs
+++ b/XML_oM/Settings/GBXMLSettings.cs
@@ -26,7 +26,7 @@ using BH.oM.Base;
 using BH.oM.Adapters.XML.Enums;
 
 using System.ComponentModel;
-using BH.oM.XML.GBXML;
+using BH.oM.Adapters.XML.GBXML;
 
 namespace BH.oM.Adapters.XML.Settings
 {

--- a/XML_oM/Versioning_62.json
+++ b/XML_oM/Versioning_62.json
@@ -1,0 +1,26 @@
+{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+      "BH.oM.XML.GBXML.RoundingSettings": "BH.oM.Adapters.XML.GBXML.RoundingSettings"
+    },
+    "ToOld": {
+      "BH.oM.Adapters.XML.GBXML.RoundingSettings": "BH.oM.XML.GBXML.RoundingSettings"
+    }
+  },
+  "Property": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "MessageForDeleted": {
+  },
+  "MessageForNoUpgrade": {
+  }
+}

--- a/XML_oM/XML_oM.csproj
+++ b/XML_oM/XML_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -123,6 +123,9 @@
     <Compile Include="Settings\GBXMLSettings.cs" />
     <Compile Include="Settings\KMLSettings.cs" />
     <Compile Include="XMLConfig.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Versioning_62.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
   <PropertyGroup>


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #573

 <!-- Add short description of what has been fixed -->

Done in support of https://github.com/BHoM/BHoM_Engine/pull/3042 as the RoundingSettings/GBXML settings was flagged as problematic from earlier versions. Please see issue as well.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Please do test with GBXML test procedure. Remember to rebuild Versioning_Toolkit after building this branch.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->