### PR TITLE
Refactor adapter to move FileSettings from XMLAdapter to XMLConfig

### DIFF
--- a/XML_Adapter/AdapterActions/Pull.cs
+++ b/XML_Adapter/AdapterActions/Pull.cs
@@ -30,6 +30,7 @@ using BH.oM.Data.Requests;
 using BH.oM.Adapter;
 using BH.oM.Base;
 using BH.Engine.Adapter;
+using BH.oM.Adapters.XML;
 
 namespace BH.Adapter.XML
 {
@@ -37,9 +38,10 @@ namespace BH.Adapter.XML
     {
         public override IEnumerable<object> Pull(IRequest request, PullType pullType = PullType.AdapterDefault, ActionConfig actionConfig = null)
         {
-            if (!System.IO.File.Exists(_fileSettings.GetFullFileName()))
+            IXMLConfig config = actionConfig as IXMLConfig;
+            if (!System.IO.File.Exists(config.File.GetFullFileName()))
             {
-                BH.Engine.Base.Compute.RecordError($"The file at {_fileSettings.GetFullFileName()} does not exist to pull from.");
+                BH.Engine.Base.Compute.RecordError($"The file at {config.File.GetFullFileName()} does not exist to pull from.");
                 return new List<IBHoMObject>();
             }
 

--- a/XML_Adapter/AdapterActions/Push.cs
+++ b/XML_Adapter/AdapterActions/Push.cs
@@ -33,6 +33,7 @@ using System.Reflection;
 using BH.oM.Adapters.XML;
 using BH.oM.Adapters.XML.Enums;
 using System.IO;
+using BH.Engine.Adapter;
 
 namespace BH.Adapter.XML
 {
@@ -85,7 +86,7 @@ namespace BH.Adapter.XML
             }
 
             if (success && config.RemoveNils)
-                RemoveNil(_fileSettings);
+                RemoveNil(config.File);
 
             return success ? objects.ToList() : new List<object>();
         }

--- a/XML_Adapter/CRUD/Bluebeam/ReadBluebeam.cs
+++ b/XML_Adapter/CRUD/Bluebeam/ReadBluebeam.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.XML
         {
             BH.oM.XML.Bluebeam.BluebeamObject report = null;
 
-            TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+            TextReader reader = new StreamReader(config.File.GetFullFileName());
             XmlSerializer szer = new XmlSerializer(typeof(BH.oM.XML.Bluebeam.MarkupSummary));
             report = (BH.oM.XML.Bluebeam.MarkupSummary)szer.Deserialize(reader);
             reader.Close();

--- a/XML_Adapter/CRUD/CSProject/CreateCSProject.cs
+++ b/XML_Adapter/CRUD/CSProject/CreateCSProject.cs
@@ -107,7 +107,7 @@ namespace BH.Adapter.XML
 
                 xmlParts.Add("</Project>");
 
-                StreamWriter sw = new StreamWriter(_fileSettings.GetFullFileName());
+                StreamWriter sw = new StreamWriter(config.File.GetFullFileName());
 
                 xmlParts = xmlParts.Select(x => Regex.Replace(x, @"<\?xml version=""1.0"" encoding=""utf-[0-9]*""\?>\r\n", "")).ToList();
                 xmlParts = xmlParts.Select(x => x.Replace("q1:", "")).ToList();

--- a/XML_Adapter/CRUD/CSProject/ReadCSProject.cs
+++ b/XML_Adapter/CRUD/CSProject/ReadCSProject.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.XML
         {
             BH.oM.XML.CSProject.Project report = null;
 
-            TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+            TextReader reader = new StreamReader(config.File.GetFullFileName());
             XmlSerializer szer = new XmlSerializer(typeof(BH.oM.XML.CSProject.Project));
             report = (BH.oM.XML.CSProject.Project)szer.Deserialize(reader);
             reader.Close();

--- a/XML_Adapter/CRUD/Default/CreateDefault.cs
+++ b/XML_Adapter/CRUD/Default/CreateDefault.cs
@@ -64,7 +64,7 @@ namespace BH.Adapter.XML
 
                 XmlSerializerNamespaces xns = new XmlSerializerNamespaces();
                 XmlSerializer szer = new XmlSerializer(exportType, overrides);
-                TextWriter ms = new StreamWriter(_fileSettings.GetFullFileName());
+                TextWriter ms = new StreamWriter(config.File.GetFullFileName());
                 foreach (var obj in objects)
                 {
                     try

--- a/XML_Adapter/CRUD/Default/ReadDefault.cs
+++ b/XML_Adapter/CRUD/Default/ReadDefault.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.XML
                 foreach (System.Reflection.PropertyInfo pi in bhomProperties)
                     overrides.Add(typeof(BHoMObject), pi.Name, new XmlAttributes { XmlIgnore = true });
 
-                TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+                TextReader reader = new StreamReader(config.File.GetFullFileName());
                 XmlSerializer szer = new XmlSerializer(type, overrides);
                 obj = System.Convert.ChangeType(szer.Deserialize(reader), type);
                 reader.Close();

--- a/XML_Adapter/CRUD/EnergyPlus/ReadEnergyPlus.cs
+++ b/XML_Adapter/CRUD/EnergyPlus/ReadEnergyPlus.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.XML
         {
             BH.oM.XML.EnergyPlus.EnergyPlusTabularReport report = null;
 
-            TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+            TextReader reader = new StreamReader(config.File.GetFullFileName());
             XmlSerializer szer = new XmlSerializer(typeof(BH.oM.XML.EnergyPlus.EnergyPlusTabularReport));
             report = (BH.oM.XML.EnergyPlus.EnergyPlusTabularReport)szer.Deserialize(reader);
             reader.Close();

--- a/XML_Adapter/CRUD/GBXML/CreateGBXML.cs
+++ b/XML_Adapter/CRUD/GBXML/CreateGBXML.cs
@@ -89,7 +89,7 @@ namespace BH.Adapter.XML
 
                 XmlSerializerNamespaces xns = new XmlSerializerNamespaces();
                 XmlSerializer szer = new XmlSerializer(typeof(BH.Adapter.XML.GBXMLSchema.GBXML), overrides);
-                TextWriter ms = new StreamWriter(_fileSettings.GetFullFileName());
+                TextWriter ms = new StreamWriter(config.File.GetFullFileName());
                 szer.Serialize(ms, gbx, xns);
                 ms.Close();
             }

--- a/XML_Adapter/CRUD/GBXML/ReadGBXML.cs
+++ b/XML_Adapter/CRUD/GBXML/ReadGBXML.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter.XML
         private IEnumerable<IBHoMObject> ReadGBXML(Type type = null, XMLConfig config = null)
         {
             BH.Adapter.XML.GBXMLSchema.GBXML gbx = null;
-            TextReader reader = new StreamReader(_fileSettings.GetFullFileName());
+            TextReader reader = new StreamReader(config.File.GetFullFileName());
             XmlSerializer szer = new XmlSerializer(typeof(BH.Adapter.XML.GBXMLSchema.GBXML));
             gbx = (BH.Adapter.XML.GBXMLSchema.GBXML)szer.Deserialize(reader);
             reader.Close();

--- a/XML_Adapter/CRUD/KML/CreateKML.cs
+++ b/XML_Adapter/CRUD/KML/CreateKML.cs
@@ -79,7 +79,7 @@ namespace BH.Adapter.XML
 
                 XmlSerializerNamespaces xns = new XmlSerializerNamespaces();
                 XmlSerializer szer = new XmlSerializer(typeof(BH.Adapter.XML.KMLSchema.KML), overrides);
-                TextWriter ms = new StreamWriter(_fileSettings.GetFullFileName());
+                TextWriter ms = new StreamWriter(config.File.GetFullFileName());
                 szer.Serialize(ms, kml, xns);
                 ms.Close();
             }

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.XML
 {
     public partial class XMLAdapter : BHoMAdapter
     {
-        [PreviousVersion("7.0", "BH.Adapter.XML.XMLAdapter(BH.oM.Adapter.Filesettings)")]
+        [PreviousVersion("7.0", "BH.Adapter.XML.XMLAdapter(BH.oM.Adapter.FileSettings)")]
         [Description("Specify XML file and properties for data transfer.")]
         [Output("adapter", "Adapter to XML.")]
         public XMLAdapter()

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.XML
     public partial class XMLAdapter : BHoMAdapter
     {
         [PreviousVersion("7.0", "BH.Adapter.XML.XMLAdapter(BH.oM.Adapter.FileSettings)")]
-        [Description("Specify XML file and properties for data transfer.")]
+        [Description("Connect to XML interoperability within the BHoM.")]
         [Output("adapter", "Adapter to XML.")]
         public XMLAdapter()
         {

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -40,8 +40,9 @@ namespace BH.Adapter.XML
 {
     public partial class XMLAdapter : BHoMAdapter
     {
-        [Description("Specify XML file and properties for data transfer")]
-        [Output("adapter", "Adapter to XML")]
+        [PreviousVersion("7.0", "BH.Adapter.XML.XMLAdapter(BH.oM.Adapter.Filesettings)")]
+        [Description("Specify XML file and properties for data transfer.")]
+        [Output("adapter", "Adapter to XML.")]
         public XMLAdapter()
         {
         }

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -41,7 +41,6 @@ namespace BH.Adapter.XML
     public partial class XMLAdapter : BHoMAdapter
     {
         [Description("Specify XML file and properties for data transfer")]
-        [Input("fileSettings", "Input the file settings to get the file name and directory the XML Adapter should use")]
         [Output("adapter", "Adapter to XML")]
         public XMLAdapter()
         {

--- a/XML_Adapter/XMLAdapter.cs
+++ b/XML_Adapter/XMLAdapter.cs
@@ -43,25 +43,9 @@ namespace BH.Adapter.XML
         [Description("Specify XML file and properties for data transfer")]
         [Input("fileSettings", "Input the file settings to get the file name and directory the XML Adapter should use")]
         [Output("adapter", "Adapter to XML")]
-        public XMLAdapter(BH.oM.Adapter.FileSettings fileSettings = null)
+        public XMLAdapter()
         {
-            if (fileSettings == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Please set the File Settings correctly to enable the XML Adapter to work correctly");
-                return;
-            }
-
-            if (!Path.HasExtension(fileSettings.FileName) || (Path.GetExtension(fileSettings.FileName) != ".xml" && Path.GetExtension(fileSettings.FileName) != ".csproj"))
-            {
-                BH.Engine.Base.Compute.RecordError("File name must contain a file extension");
-                return;
-            }
-
-            _fileSettings = fileSettings;
-
         }
-
-        private BH.oM.Adapter.FileSettings _fileSettings { get; set; } = null;
     }
 }
 

--- a/XML_oM/Config/IXMLConfig.cs
+++ b/XML_oM/Config/IXMLConfig.cs
@@ -1,0 +1,13 @@
+﻿using BH.oM.Adapter;
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BH.oM.Adapters.XML
+{
+    public interface IXMLConfig : IObject
+    {
+        FileSettings File { get; set; }
+    }
+}

--- a/XML_oM/Config/IXMLConfig.cs
+++ b/XML_oM/Config/IXMLConfig.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Adapter;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;

--- a/XML_oM/Config/XMLConfig.cs
+++ b/XML_oM/Config/XMLConfig.cs
@@ -35,8 +35,11 @@ using System.ComponentModel;
 namespace BH.oM.Adapters.XML
 {
     [Description("Define configuration settings for pushing and pulling XML files using the XML Adapter.")]
-    public class XMLConfig : ActionConfig
+    public class XMLConfig : ActionConfig, IXMLConfig
     {
+        [Description("File settings for the file to push to or pull from.")]
+        public virtual FileSettings File { get; set; } = null;
+
         [Description("Define the schema which the XML Adapter should be operating with.")]
         public virtual Schema Schema { get; set; } = Schema.Undefined;
 
@@ -47,6 +50,3 @@ namespace BH.oM.Adapters.XML
         public virtual bool RemoveNils { get; set; } = false;
     }
 }
-
-
-


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #592 

 <!-- Add short description of what has been fixed -->
- File settings attribute removed from `XMLAdapter` and placed in `XMLConfig`.
- `XMLConfig` is now an `IXMLConfig` and any future configs must contain a file settings attribute.
- CRUD methods have been updated to use `config.File` rather than `_fileSettings`
