### PR TITLE
Functional tests for pushing GBXML files

### DIFF
--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -24,6 +24,7 @@ namespace BH.Tests.Adapter.XML
         XMLAdapter m_adapter;
         XMLConfig m_config;
         List<IBHoMObject> m_jsonObjects;
+        List<Panel> m_jsonPanels;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -38,6 +39,7 @@ namespace BH.Tests.Adapter.XML
                 File = new FileSettings() { Directory = ModelsPath, FileName = "PushedModel.xml"},
             };
             m_jsonObjects = BH.Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(ModelsPath, "TestModel.json"), true).Cast<IBHoMObject>().ToList();
+            m_jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects);
         }
 
         [SetUp]
@@ -78,12 +80,11 @@ namespace BH.Tests.Adapter.XML
             List<IBHoMObject> objs = m_adapter.Pull(request, actionConfig: m_config).Cast<IBHoMObject>().ToList();
 
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
-            List<Panel> jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects);
             List<Construction> constructions = objs.Where(x => x.GetType() == typeof(Construction)).Cast<Construction>().ToList();
             List<Construction> jsonConstructions = m_jsonObjects.Where(x => x.GetType() == typeof(Construction) && x.Name == "generic_construction").Cast<Construction>().ToList();
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
-            jsonPanels = BH.Engine.Data.Query.OrderBy(jsonPanels, "Name");
+            List<Panel> jsonPanels = BH.Engine.Data.Query.OrderBy(m_jsonPanels, "Name");
 
             //assert correct values
             pulledPanels.Count.Should().Be(jsonPanels.Count, "There was a different number of panels pushed then pulled compared to expected.");
@@ -114,11 +115,10 @@ namespace BH.Tests.Adapter.XML
             List<IBHoMObject> objs = m_adapter.Pull(request, actionConfig: m_config).Cast<IBHoMObject>().ToList();
 
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
-            List<Panel> jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects);
             List<Construction> constructions = objs.Where(x => x.GetType() == typeof(Construction)).Cast<Construction>().ToList();
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
-            jsonPanels = BH.Engine.Data.Query.OrderBy(jsonPanels, "Name");
+            List<Panel> jsonPanels = BH.Engine.Data.Query.OrderBy(m_jsonPanels, "Name");
 
             //assert correct values
             pulledPanels.Count.Should().Be(jsonPanels.Count, "There was a different number of panels pushed then pulled compared to expected.");
@@ -144,16 +144,17 @@ namespace BH.Tests.Adapter.XML
             };
             FilterRequest request = new FilterRequest();
 
+            //push, then pull objects
             m_adapter.Push(m_jsonObjects, actionConfig: m_config);
             List<IBHoMObject> objs = m_adapter.Pull(request, actionConfig: m_config).Cast<IBHoMObject>().ToList();
 
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
-            List<Panel> jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects); //perhaps refactor to be m_jsonPanels
             List<Construction> constructions = objs.Where(x => x.GetType() == typeof(Construction)).Cast<Construction>().ToList();
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
-            jsonPanels = BH.Engine.Data.Query.OrderBy(jsonPanels.ToSpaces().ExternalElements(), "Name");
+            List<Panel> jsonPanels = BH.Engine.Data.Query.OrderBy(m_jsonPanels.ToSpaces().ExternalElements(), "Name");
 
+            //assert correct values
             pulledPanels.Count.Should().Be(jsonPanels.Count, "There was a different number of external panels pulled compared to expected.");
             for (int i = 0; i < jsonPanels.Count; i++)
             {

--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -1,4 +1,26 @@
-﻿using NUnit.Framework;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using NUnit.Framework;
 using FluentAssertions;
 using System;
 using System.Collections.Generic;
@@ -37,6 +59,7 @@ namespace BH.Tests.Adapter.XML
             m_config = new XMLConfig()
             {
                 File = new FileSettings() { Directory = ModelsPath, FileName = "PushedModel.xml"},
+                Schema = oM.Adapters.XML.Enums.Schema.GBXML
             };
             m_jsonObjects = BH.Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(ModelsPath, "TestModel.json"), true).Cast<IBHoMObject>().ToList();
             m_jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects);
@@ -67,11 +90,17 @@ namespace BH.Tests.Adapter.XML
         [Description("Test for pushing a set of BHoM environment objects to xml with constructions set to true.")]
         public void PushGBXML()
         {
-            m_config.Schema = oM.Adapters.XML.Enums.Schema.GBXML;
             m_config.Settings = new GBXMLSettings() 
             {
                 IncludeConstructions = true,
-                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.Full
+                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.Full,
+                UnitSetUp = new GBXMLUnitSetUp()
+                {
+                    TemperatureUnit = TemperatureUnit.Celcius,
+                    LengthUnit = LengthUnit.Meters,
+                    AreaUnit = AreaUnit.SquareMeters,
+                    VolumeUnit = VolumeUnit.CubicMeters
+                }
             };
             FilterRequest request = new FilterRequest();
 
@@ -102,11 +131,17 @@ namespace BH.Tests.Adapter.XML
         [Description("Test for pushing a set of BHoM environment objects to xml with constructions set to false.")]
         public void PushGBXMLNoConstructions()
         {
-            m_config.Schema = oM.Adapters.XML.Enums.Schema.GBXML;
             m_config.Settings = new GBXMLSettings() 
             { 
                 IncludeConstructions = false,
-                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.Full
+                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.Full,
+                UnitSetUp = new GBXMLUnitSetUp()
+                {
+                    TemperatureUnit = TemperatureUnit.Celcius,
+                    LengthUnit = LengthUnit.Meters,
+                    AreaUnit = AreaUnit.SquareMeters,
+                    VolumeUnit = VolumeUnit.CubicMeters
+                }
             };
             FilterRequest request = new FilterRequest();
 
@@ -136,11 +171,17 @@ namespace BH.Tests.Adapter.XML
         [Description("Test for pushing GBXML with exportDetail set to BuildingShell")]
         public void PushGBXMLBuildingShell()
         {
-            m_config.Schema = oM.Adapters.XML.Enums.Schema.GBXML;
             m_config.Settings = new GBXMLSettings()
             {
                 IncludeConstructions = false,
-                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.BuildingShell
+                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.BuildingShell,
+                UnitSetUp = new GBXMLUnitSetUp()
+                {
+                    TemperatureUnit = TemperatureUnit.Celcius,
+                    LengthUnit = LengthUnit.Meters,
+                    AreaUnit = AreaUnit.SquareMeters,
+                    VolumeUnit = VolumeUnit.CubicMeters
+                }
             };
             FilterRequest request = new FilterRequest();
 
@@ -164,6 +205,33 @@ namespace BH.Tests.Adapter.XML
             constructions.Count.Should().Be(0, "No constructions should be pulled, but some were pulled anyway.");
 
             objs.Count.Should().Be(42, "There was a different number of objects pulled compared to expected.");
+        }
+
+        [Test]
+        [Description("Test for pushing GBXML with different units set.")]
+        public void PushGBXMLUnits()
+        {
+            m_config.Settings = new GBXMLSettings()
+            {
+                IncludeConstructions = false,
+                ExportDetail = oM.Adapters.XML.Enums.ExportDetail.Full,
+                UnitSetUp = new GBXMLUnitSetUp()
+                {
+                    TemperatureUnit = TemperatureUnit.Kelvin,
+                    LengthUnit = LengthUnit.Feet,
+                    AreaUnit = AreaUnit.SquareFeet,
+                    VolumeUnit = VolumeUnit.CubicFeet
+                }
+            };
+            
+            m_adapter.Push(m_jsonObjects, actionConfig: m_config);
+
+            List<string> lines = File.ReadAllLines(m_config.File.GetFullFileName()).ToList();
+
+            lines[1].Should().Contain("lengthUnit=\"Feet\"", "The length unit was not set to Feet.");
+            lines[1].Should().Contain("areaUnit=\"SquareFeet\"", "The area unit was not set to Square Feet.");
+            lines[1].Should().Contain("volumeUnit=\"CubicFeet\"", "The volume unit was not set to Cubic Feet.");
+            lines[1].Should().Contain("temperatureUnit=\"K\"", "The temperature unit was not set to Kelvin.");
         }
     }
 }

--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -28,16 +28,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.Adapter.XML;
-using BH.oM.Adapters.XML;
-using BH.oM.Adapter;
+using BH.Engine.Environment;
 using BH.Engine.Adapter;
 using BH.Engine.Adapters.XML;
+using BH.oM.Adapters.XML;
+using BH.oM.Adapter;
 using BH.oM.Adapters.XML.Settings;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
 using BH.oM.Environment.Elements;
 using BH.oM.Physical.Constructions;
-using BH.Engine.Environment;
 
 namespace BH.Tests.Adapter.XML
 {

--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -1,0 +1,55 @@
+﻿using NUnit.Framework;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.Adapter.XML;
+using BH.oM.Adapters.XML;
+using BH.oM.Adapter;
+using BH.Engine.Adapter;
+
+namespace BH.Tests.Adapter.XML
+{
+    public class PushTests
+    {
+        XMLAdapter m_adapter;
+        XMLConfig m_config;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            string currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            List<string> paths = currentDirectory.Split('\\').ToList();
+            paths = paths.Take(paths.IndexOf(".ci") + 2).ToList();
+            string ModelsPath = Path.Join(string.Join("\\", paths), "Models");
+            m_adapter = new XMLAdapter();
+            m_config = new XMLConfig()
+            {
+                File = new FileSettings() { Directory = ModelsPath, FileName = "PushedModel.xml"}
+            };
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            BH.Engine.Base.Compute.ClearCurrentEvents();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            File.Delete(m_config.File.GetFullFileName());
+            var events = Engine.Base.Query.CurrentEvents();
+            if (events.Any())
+            {
+                Console.WriteLine("BHoM Events raised during execution:");
+                foreach (var ev in events)
+                {
+                    Console.WriteLine($"{ev.Type}: {ev.Message}");
+                }
+            }
+        }
+    }
+}

--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -73,8 +73,6 @@ namespace BH.Tests.Adapter.XML
             };
             FilterRequest request = new FilterRequest();
 
-            List<IBHoMObject> jsonObjs = BH.Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_config.File.Directory, "TestModel.json"), true).Cast<IBHoMObject>().ToList();
-
             //Push, then pull objects.
             m_adapter.Push(m_jsonObjects, actionConfig: m_config);
             List<IBHoMObject> objs = m_adapter.Pull(request, actionConfig: m_config).Cast<IBHoMObject>().ToList();
@@ -82,7 +80,7 @@ namespace BH.Tests.Adapter.XML
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
             List<Panel> jsonPanels = BH.Engine.Environment.Query.Panels(m_jsonObjects);
             List<Construction> constructions = objs.Where(x => x.GetType() == typeof(Construction)).Cast<Construction>().ToList();
-            List<Construction> jsonConstructions = objs.Where(x => x.GetType() == typeof(Construction) && x.Name == "generic_construction").Cast<Construction>().ToList();
+            List<Construction> jsonConstructions = m_jsonObjects.Where(x => x.GetType() == typeof(Construction) && x.Name == "generic_construction").Cast<Construction>().ToList();
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
             jsonPanels = BH.Engine.Data.Query.OrderBy(jsonPanels, "Name");

--- a/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/XML_Adapter_Tests/PushTests.cs
@@ -22,7 +22,6 @@ namespace BH.Tests.Adapter.XML
     {
         XMLAdapter m_adapter;
         XMLConfig m_config;
-        GBXMLSettings m_settings;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -36,7 +35,6 @@ namespace BH.Tests.Adapter.XML
             {
                 File = new FileSettings() { Directory = ModelsPath, FileName = "PushedModel.xml"},
             };
-            m_settings = new GBXMLSettings();
         }
 
         [SetUp]
@@ -61,11 +59,11 @@ namespace BH.Tests.Adapter.XML
         }
 
         [Test]
+        [Description("Test for pushing a set of BHoM environment objects to xml with constructions set to true.")]
         public void PushGBXML()
         {
             m_config.Schema = oM.Adapters.XML.Enums.Schema.GBXML;
-            m_settings.IncludeConstructions = true;
-            m_config.Settings = m_settings;
+            m_config.Settings = new GBXMLSettings() { IncludeConstructions = true };
             FilterRequest request = new FilterRequest();
 
             List<IBHoMObject> jsonObjs = BH.Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_config.File.Directory, "TestModel.json"), true).Cast<IBHoMObject>().ToList();
@@ -82,6 +80,7 @@ namespace BH.Tests.Adapter.XML
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
             jsonPanels = BH.Engine.Data.Query.OrderBy(jsonPanels, "Name");
 
+            //assert correct values
             pulledPanels.Count.Should().Be(jsonPanels.Count, "There was a different number of panels pushed then pulled compared to expected.");
             for (int i = 0; i < pulledPanels.Count; i++)
             {
@@ -89,8 +88,8 @@ namespace BH.Tests.Adapter.XML
                 pulledPanels[i].IsIdentical(jsonPanels[i]).Should().BeTrue("The panel with name {pulledPanels[i].Name} was not identical to the json panel with the same name.");
             }
             constructions.Count.Should().Be(jsonConstructions.Count, "There is only one type of construction (generic_construction) used in the building.");
-            
 
+            objs.Count.Should().Be(jsonObjs.Count-3, "The number of pulled objects should be the same as the number of json objects, minus unused constructions.");
         }
     }
 }

--- a/.ci/unit-tests/XML_Adapter_Tests/XML_Adapter_Tests.csproj
+++ b/.ci/unit-tests/XML_Adapter_Tests/XML_Adapter_Tests.csproj
@@ -86,6 +86,11 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
+    <Reference Include="TriangleNet_Engine">
+      <HintPath>$(ProgramData)\BHoM\Assemblies\TriangleNet_Engine.dll</HintPath>
+		<SpecificVersion>False</SpecificVersion>
+		<Private>True</Private>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #595 

 <!-- Add short description of what has been fixed -->
Functional tests for the the pull action have been created that test a number of scenarios:
- Pushing BHoM environment objects to GBXML
    - Pushing full building
    - Pushing building shell
    - Pushing SI and non-SI units
    - Pushing with and without construction objects

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
Uses the JSON serialised BHoM objects to push to GBXML and compare.